### PR TITLE
[ПЕРЕСДАЧА] Хохлов Андрей Дмитриевич 3822Б1ФИ2 OMP

### DIFF
--- a/tasks/omp/khokhlov_a_shell_omp/func_tests/main.cpp
+++ b/tasks/omp/khokhlov_a_shell_omp/func_tests/main.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/khokhlov_a_shell_omp/include/ops_omp.hpp"
+
+TEST(khokhlov_a_shell_omp, Shell_Validation_Fail) {
+  // Create data
+  std::vector<int> in1 = khokhlov_a_shell_omp::GenerateRandomVector(10);
+  std::vector<int> in2 = std::vector<int>(5);
+  std::vector<int> out(10, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> test_task_omp = std::make_shared<ppc::core::TaskData>();
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in1.data()));
+  test_task_omp->inputs_count.emplace_back(in1.size());
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in2.data()));
+  test_task_omp->inputs_count.emplace_back(in2.size());
+  test_task_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  test_task_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  khokhlov_a_shell_omp::ShellOmp test_task_omp_task(test_task_omp);
+  ASSERT_EQ(test_task_omp_task.ValidationImpl(), false);
+}
+
+TEST(khokhlov_a_shell_omp, Shell_Random_10) {
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(10);
+  std::vector<int> out(10, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> test_task_omp = std::make_shared<ppc::core::TaskData>();
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  test_task_omp->inputs_count.emplace_back(in.size());
+  test_task_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  test_task_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  khokhlov_a_shell_omp::ShellOmp test_task_omp_task(test_task_omp);
+  ASSERT_EQ(test_task_omp_task.ValidationImpl(), true);
+  test_task_omp_task.PreProcessingImpl();
+  test_task_omp_task.RunImpl();
+  test_task_omp_task.PostProcessingImpl();
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}
+
+TEST(khokhlov_a_shell_omp, Shell_Random_20) {
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(20);
+  std::vector<int> out(20, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> test_task_omp = std::make_shared<ppc::core::TaskData>();
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  test_task_omp->inputs_count.emplace_back(in.size());
+  test_task_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  test_task_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  khokhlov_a_shell_omp::ShellOmp test_task_omp_task(test_task_omp);
+  ASSERT_EQ(test_task_omp_task.ValidationImpl(), true);
+  test_task_omp_task.PreProcessingImpl();
+  test_task_omp_task.RunImpl();
+  test_task_omp_task.PostProcessingImpl();
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}
+
+TEST(khokhlov_a_shell_omp, Shell_Random_50) {
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(50);
+  std::vector<int> out(50, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> test_task_omp = std::make_shared<ppc::core::TaskData>();
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  test_task_omp->inputs_count.emplace_back(in.size());
+  test_task_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  test_task_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  khokhlov_a_shell_omp::ShellOmp test_task_omp_task(test_task_omp);
+  ASSERT_EQ(test_task_omp_task.ValidationImpl(), true);
+  test_task_omp_task.PreProcessingImpl();
+  test_task_omp_task.RunImpl();
+  test_task_omp_task.PostProcessingImpl();
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}
+
+TEST(khokhlov_a_shell_omp, Shell_Random_70) {
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(70);
+  std::vector<int> out(70, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> test_task_omp = std::make_shared<ppc::core::TaskData>();
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  test_task_omp->inputs_count.emplace_back(in.size());
+  test_task_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  test_task_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  khokhlov_a_shell_omp::ShellOmp test_task_omp_task(test_task_omp);
+  ASSERT_EQ(test_task_omp_task.ValidationImpl(), true);
+  test_task_omp_task.PreProcessingImpl();
+  test_task_omp_task.RunImpl();
+  test_task_omp_task.PostProcessingImpl();
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}
+
+TEST(khokhlov_a_shell_omp, Shell_Random_100) {
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(100);
+  std::vector<int> out(100, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> test_task_omp = std::make_shared<ppc::core::TaskData>();
+  test_task_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  test_task_omp->inputs_count.emplace_back(in.size());
+  test_task_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  test_task_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  khokhlov_a_shell_omp::ShellOmp test_task_omp_task(test_task_omp);
+  ASSERT_EQ(test_task_omp_task.ValidationImpl(), true);
+  test_task_omp_task.PreProcessingImpl();
+  test_task_omp_task.RunImpl();
+  test_task_omp_task.PostProcessingImpl();
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}

--- a/tasks/omp/khokhlov_a_shell_omp/include/ops_omp.hpp
+++ b/tasks/omp/khokhlov_a_shell_omp/include/ops_omp.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace khokhlov_a_shell_omp {
+
+class ShellOmp : public ppc::core::Task {
+ public:
+  explicit ShellOmp(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  static std::vector<int> ShellSort(const std::vector<int>& input);
+  std::vector<int> input_;
+};
+
+bool CheckSorted(const std::vector<int>& input);
+
+std::vector<int> GenerateRandomVector(int size);
+
+}  // namespace khokhlov_a_shell_omp

--- a/tasks/omp/khokhlov_a_shell_omp/perf_tests/main.cpp
+++ b/tasks/omp/khokhlov_a_shell_omp/perf_tests/main.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/khokhlov_a_shell_omp/include/ops_omp.hpp"
+
+TEST(khokhlov_a_shell_omp, pipeline_run_omp) {
+  const int count = 2000000;
+
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(count);
+  std::vector<int> out(count, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task = std::make_shared<khokhlov_a_shell_omp::ShellOmp>(task_data);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}
+
+TEST(khokhlov_a_shell_omp, task_run_omp) {
+  const int count = 6000000;
+
+  // Create data
+  std::vector<int> in = khokhlov_a_shell_omp::GenerateRandomVector(count);
+  std::vector<int> out(count, 0);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task = std::make_shared<khokhlov_a_shell_omp::ShellOmp>(task_data);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_TRUE(khokhlov_a_shell_omp::CheckSorted(out));
+}

--- a/tasks/omp/khokhlov_a_shell_omp/src/ops_omp.cpp
+++ b/tasks/omp/khokhlov_a_shell_omp/src/ops_omp.cpp
@@ -1,0 +1,85 @@
+#include "omp/khokhlov_a_shell_omp/include/ops_omp.hpp"
+
+#include <algorithm>
+#include <random>
+#include <vector>
+#include <omp.h>
+
+bool khokhlov_a_shell_omp::ShellOmp::PreProcessingImpl() {
+  // Init value for input and output
+  for (int i = 0; i < static_cast<int>(task_data->inputs_count[0]); i++) {
+    input_.push_back(reinterpret_cast<int*>(task_data->inputs[0])[i]);
+  }
+  return true;
+}
+
+bool khokhlov_a_shell_omp::ShellOmp::ValidationImpl() {
+  // Check equality of counts elements
+  return task_data->inputs_count.size() == 1 && task_data->inputs_count[0] > 0 &&
+         task_data->outputs_count.size() == 1 && task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool khokhlov_a_shell_omp::ShellOmp::RunImpl() {
+  input_ = ShellSort(input_);
+  return true;
+}
+
+bool khokhlov_a_shell_omp::ShellOmp::PostProcessingImpl() {
+  for (int i = 0; i < static_cast<int>(task_data->inputs_count[0]); i++) {
+    reinterpret_cast<int*>(task_data->outputs[0])[i] = input_[i];
+  }
+  return true;
+}
+
+std::vector<int> khokhlov_a_shell_omp::ShellOmp::ShellSort(const std::vector<int>& input) {
+  std::vector<int> vec(input);
+  int n = static_cast<int>(vec.size());
+  int num_threads = omp_get_max_threads();
+  int chunk_size = (n + num_threads - 1) / num_threads;
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    int thread_id = omp_get_thread_num();
+    int start = thread_id * chunk_size;
+    int end = std::min(start + chunk_size, n);
+
+    for (int interval = (end - start) / 2; interval > 0; interval /= 2) {
+      for (int i = start + interval; i < end; i++) {
+        int tmp = vec[i];
+        int j = i;
+        for (; j >= start + interval && vec[j - interval] > tmp; j -= interval) {
+          vec[j] = vec[j - interval];
+        }
+        vec[j] = tmp;
+      }
+    }
+  }
+
+  for (int interval = n / 2; interval > 0; interval /= 2) {
+    for (int i = interval; i < n; i++) {
+      int tmp = vec[i];
+      int j = i;
+      for (; j >= interval && vec[j - interval] > tmp; j -= interval) {
+        vec[j] = vec[j - interval];
+      }
+      vec[j] = tmp;
+    }
+  }
+
+  return vec;
+}
+
+bool khokhlov_a_shell_omp::CheckSorted(const std::vector<int>& input) { return std::ranges::is_sorted(input); }
+
+std::vector<int> khokhlov_a_shell_omp::GenerateRandomVector(int size) {
+  std::random_device rnd_device;
+  std::mt19937 mersenne_engine{rnd_device()};
+  std::uniform_int_distribution<int> dist{1, 100};
+
+  auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+
+  std::vector<int> vec(size);
+  std::ranges::generate(vec, gen);
+
+  return vec;
+}

--- a/tasks/omp/khokhlov_a_shell_omp/src/ops_omp.cpp
+++ b/tasks/omp/khokhlov_a_shell_omp/src/ops_omp.cpp
@@ -1,9 +1,10 @@
 #include "omp/khokhlov_a_shell_omp/include/ops_omp.hpp"
 
+#include <omp.h>
+
 #include <algorithm>
 #include <random>
 #include <vector>
-#include <omp.h>
 
 bool khokhlov_a_shell_omp::ShellOmp::PreProcessingImpl() {
   // Init value for input and output
@@ -37,7 +38,7 @@ std::vector<int> khokhlov_a_shell_omp::ShellOmp::ShellSort(const std::vector<int
   int num_threads = omp_get_max_threads();
   int chunk_size = (n + num_threads - 1) / num_threads;
 
-  #pragma omp parallel num_threads(num_threads)
+#pragma omp parallel num_threads(num_threads)
   {
     int thread_id = omp_get_thread_num();
     int start = thread_id * chunk_size;


### PR DESCRIPTION
15 вариант - Сортировка Шелла с простым слиянием.
На вход подается случайный массив, на выходе отсортированных.
Алгоритмическая сложность в лучшем и среднем случаях O(nlogn), в худшем O(n^2).
Изменения:
Массив делится на num_threads кусков, 
где каждый поток сортирует свой кусок независимо с помощью сортировки Шелла.
Границы кусков вычисляются как start = thread_id * chunk_size и end = min(start + chunk_size, n)
После параллельной сортировки кусков выполняется финальный последовательный проход сортировки Шелла по всему массиву для устранения несоответствий на границах кусков.