### PR TITLE
[ПЕРЕСДАЧА] Мурадов Камал Ровшан оглы 3822Б1ПР4 SEQ

### DIFF
--- a/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <ranges>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -27,7 +29,6 @@ TEST(muradov_k_histogram_stretch_seq, stretch_small_vector) {
   ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
-  // Ожидаемое преобразование
   std::vector<int> expected{0, (10 * 255) / 40, (20 * 255) / 40, (30 * 255) / 40, 255};
   EXPECT_EQ(out, expected);
 }
@@ -41,8 +42,7 @@ TEST(muradov_k_histogram_stretch_seq, stretch_constant) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  // Все должны стать 0
-  EXPECT_TRUE(std::all_of(out.begin(), out.end(), [](int v) { return v == 0; }));
+  EXPECT_TRUE(std::ranges::all_of(out, [](int v) { return v == 0; }));
 }
 
 TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
@@ -55,7 +55,9 @@ TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
 
 TEST(muradov_k_histogram_stretch_seq, stretch_full_range_preserve) {
   std::vector<int> in(256, 0);
-  for (int i = 0; i < 256; ++i) in[i] = i;  // полный диапазон
+  for (int i = 0; i < 256; ++i) {
+    in[i] = i;
+  }
   std::vector<int> out(in.size(), 0);
   auto td = MakeTaskData(in, out);
   muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
@@ -63,7 +65,7 @@ TEST(muradov_k_histogram_stretch_seq, stretch_full_range_preserve) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  EXPECT_EQ(out, in);  // линейное отображение тождественно
+  EXPECT_EQ(out, in);
 }
 
 TEST(muradov_k_histogram_stretch_seq, output_min_zero_max_255) {
@@ -75,7 +77,7 @@ TEST(muradov_k_histogram_stretch_seq, output_min_zero_max_255) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  auto mm = std::minmax_element(out.begin(), out.end());
-  EXPECT_EQ(*mm.first, 0);
-  EXPECT_EQ(*mm.second, 255);
+  auto mm = std::ranges::minmax_element(out);
+  EXPECT_EQ(*mm.min, 0);
+  EXPECT_EQ(*mm.max, 255);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+#include <algorithm>
+
+#include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+std::shared_ptr<ppc::core::TaskData> MakeTaskData(std::vector<int>& in, std::vector<int>& out) {
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  td->inputs_count.emplace_back(in.size());
+  td->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  td->outputs_count.emplace_back(out.size());
+  return td;
+}
+}
+
+TEST(muradov_k_histogram_stretch_seq, stretch_small_vector) {
+  std::vector<int> in{10, 20, 30, 40, 50};
+  std::vector<int> out(in.size(), -1);
+  auto td = MakeTaskData(in, out);
+  muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  // Ожидаемое преобразование
+  std::vector<int> expected{0, (10*255)/40, (20*255)/40, (30*255)/40, 255};
+  EXPECT_EQ(out, expected);
+}
+
+TEST(muradov_k_histogram_stretch_seq, stretch_constant) {
+  std::vector<int> in(100, 77);
+  std::vector<int> out(in.size(), -1);
+  auto td = MakeTaskData(in, out);
+  muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  // Все должны стать 0
+  EXPECT_TRUE(std::all_of(out.begin(), out.end(), [](int v){return v==0;}));
+}
+
+TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
+  std::vector<int> in{0, 10, 260}; // 260 вне диапазона
+  std::vector<int> out(in.size(), 0);
+  auto td = MakeTaskData(in, out);
+  muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
+  EXPECT_FALSE(task.Validation());
+}
+
+TEST(muradov_k_histogram_stretch_seq, stretch_full_range_preserve) {
+  std::vector<int> in(256, 0);
+  for (int i=0;i<256;++i) in[i]=i; // полный диапазон
+  std::vector<int> out(in.size(), 0);
+  auto td = MakeTaskData(in, out);
+  muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_EQ(out, in); // линейное отображение тождественно
+}
+
+TEST(muradov_k_histogram_stretch_seq, output_min_zero_max_255) {
+  std::vector<int> in{50, 60, 200, 180, 55, 190};
+  std::vector<int> out(in.size(), 0);
+  auto td = MakeTaskData(in, out);
+  muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  auto mm = std::minmax_element(out.begin(), out.end());
+  EXPECT_EQ(*mm.first, 0);
+  EXPECT_EQ(*mm.second, 255);
+}

--- a/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
-#include <algorithm>
 
-#include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
 #include "core/task/include/task.hpp"
+#include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
 
 namespace {
 std::shared_ptr<ppc::core::TaskData> MakeTaskData(std::vector<int>& in, std::vector<int>& out) {
@@ -16,7 +16,7 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(std::vector<int>& in, std::vec
   td->outputs_count.emplace_back(out.size());
   return td;
 }
-}
+}  // namespace
 
 TEST(muradov_k_histogram_stretch_seq, stretch_small_vector) {
   std::vector<int> in{10, 20, 30, 40, 50};
@@ -28,7 +28,7 @@ TEST(muradov_k_histogram_stretch_seq, stretch_small_vector) {
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   // Ожидаемое преобразование
-  std::vector<int> expected{0, (10*255)/40, (20*255)/40, (30*255)/40, 255};
+  std::vector<int> expected{0, (10 * 255) / 40, (20 * 255) / 40, (30 * 255) / 40, 255};
   EXPECT_EQ(out, expected);
 }
 
@@ -42,11 +42,11 @@ TEST(muradov_k_histogram_stretch_seq, stretch_constant) {
   task.Run();
   task.PostProcessing();
   // Все должны стать 0
-  EXPECT_TRUE(std::all_of(out.begin(), out.end(), [](int v){return v==0;}));
+  EXPECT_TRUE(std::all_of(out.begin(), out.end(), [](int v) { return v == 0; }));
 }
 
 TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
-  std::vector<int> in{0, 10, 260}; // 260 вне диапазона
+  std::vector<int> in{0, 10, 260};
   std::vector<int> out(in.size(), 0);
   auto td = MakeTaskData(in, out);
   muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
@@ -55,7 +55,7 @@ TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
 
 TEST(muradov_k_histogram_stretch_seq, stretch_full_range_preserve) {
   std::vector<int> in(256, 0);
-  for (int i=0;i<256;++i) in[i]=i; // полный диапазон
+  for (int i = 0; i < 256; ++i) in[i] = i;  // полный диапазон
   std::vector<int> out(in.size(), 0);
   auto td = MakeTaskData(in, out);
   muradov_k_histogram_stretch_seq::HistogramStretchSequential task(td);
@@ -63,7 +63,7 @@ TEST(muradov_k_histogram_stretch_seq, stretch_full_range_preserve) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  EXPECT_EQ(out, in); // линейное отображение тождественно
+  EXPECT_EQ(out, in);  // линейное отображение тождественно
 }
 
 TEST(muradov_k_histogram_stretch_seq, output_min_zero_max_255) {

--- a/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <ranges>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -42,7 +41,7 @@ TEST(muradov_k_histogram_stretch_seq, stretch_constant) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  EXPECT_TRUE(std::ranges::all_of(out, [](int v) { return v == 0; }));
+  EXPECT_TRUE(std::all_of(out.begin(), out.end(), [](int v) { return v == 0; }));
 }
 
 TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
@@ -77,7 +76,7 @@ TEST(muradov_k_histogram_stretch_seq, output_min_zero_max_255) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  auto mm = std::ranges::minmax_element(out);
-  EXPECT_EQ(*mm.min, 0);
-  EXPECT_EQ(*mm.max, 255);
+  auto mm = std::minmax_element(out.begin(), out.end());
+  EXPECT_EQ(*mm.first, 0);
+  EXPECT_EQ(*mm.second, 255);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/func_tests/main.cpp
@@ -41,7 +41,7 @@ TEST(muradov_k_histogram_stretch_seq, stretch_constant) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  EXPECT_TRUE(std::all_of(out.begin(), out.end(), [](int v) { return v == 0; }));
+  EXPECT_TRUE(std::ranges::all_of(out, [](int v) { return v == 0; }));
 }
 
 TEST(muradov_k_histogram_stretch_seq, validation_invalid_range) {
@@ -76,7 +76,7 @@ TEST(muradov_k_histogram_stretch_seq, output_min_zero_max_255) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  auto mm = std::minmax_element(out.begin(), out.end());
-  EXPECT_EQ(*mm.first, 0);
-  EXPECT_EQ(*mm.second, 255);
+  auto mm = std::ranges::minmax_element(out);
+  EXPECT_EQ(*mm.min, 0);
+  EXPECT_EQ(*mm.max, 255);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/include/ops_seq.hpp
+++ b/tasks/seq/muradov_k_histogram_stretch/include/ops_seq.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <utility>
 #include <vector>
 

--- a/tasks/seq/muradov_k_histogram_stretch/include/ops_seq.hpp
+++ b/tasks/seq/muradov_k_histogram_stretch/include/ops_seq.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+#include <algorithm>
+
+#include "core/task/include/task.hpp"
+
+namespace muradov_k_histogram_stretch_seq {
+
+class HistogramStretchSequential : public ppc::core::Task {
+ public:
+  explicit HistogramStretchSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_image_, output_image_;
+  int min_val_{0};
+  int max_val_{0};
+};
+
+}  // namespace muradov_k_histogram_stretch_seq

--- a/tasks/seq/muradov_k_histogram_stretch/include/ops_seq.hpp
+++ b/tasks/seq/muradov_k_histogram_stretch/include/ops_seq.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <utility>
 #include <vector>
-#include <algorithm>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -24,7 +24,7 @@ void ExtraCheck(const std::vector<int>& out) {
 }  // namespace
 
 TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
-  const int k_size = 700000;
+  const int k_size = 600000;
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(42);
@@ -42,7 +42,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 7;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();
@@ -62,7 +62,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
 }
 
 TEST(muradov_k_histogram_stretch_seq, test_task_run) {
-  const int k_size = 700000;
+  const int k_size = 600000;
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(777);
@@ -80,7 +80,7 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 7;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -11,18 +11,6 @@
 #include "core/task/include/task.hpp"
 #include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
 
-namespace {
-void ExtraCheck(const std::vector<int>& out) {
-  volatile int sum = 0;
-  for (int r = 0; r < 32; ++r) {
-    for (int v : out) {
-      sum += v & 1;
-    }
-  }
-  (void)sum;
-}
-}  // namespace
-
 TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   const int k_size = 600000;
   std::vector<int> in(k_size);
@@ -58,7 +46,6 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   auto mm = std::ranges::minmax_element(out);
   ASSERT_EQ(*mm.min, 0);
   ASSERT_EQ(*mm.max, 255);
-  ExtraCheck(out);
 }
 
 TEST(muradov_k_histogram_stretch_seq, test_task_run) {
@@ -96,5 +83,4 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   auto mm = std::ranges::minmax_element(out);
   ASSERT_EQ(*mm.min, 0);
   ASSERT_EQ(*mm.max, 255);
-  ExtraCheck(out);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -62,7 +62,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
 }
 
 TEST(muradov_k_histogram_stretch_seq, test_task_run) {
-  const int k_size = 600000;  // restart job
+  const int k_size = 600000;
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(777);

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -62,7 +62,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
 }
 
 TEST(muradov_k_histogram_stretch_seq, test_task_run) {
-  const int k_size = 600000;
+  const int k_size = 600000;  // restart job
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(777);

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -42,7 +42,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 7;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();
@@ -80,7 +80,7 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 7;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -55,9 +55,9 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  auto mm = std::minmax_element(out.begin(), out.end());
-  ASSERT_EQ(*mm.first, 0);
-  ASSERT_EQ(*mm.second, 255);
+  auto mm = std::ranges::minmax_element(out);
+  ASSERT_EQ(*mm.min, 0);
+  ASSERT_EQ(*mm.max, 255);
   ExtraCheck(out);
 }
 
@@ -93,8 +93,8 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  auto mm = std::minmax_element(out.begin(), out.end());
-  ASSERT_EQ(*mm.first, 0);
-  ASSERT_EQ(*mm.second, 255);
+  auto mm = std::ranges::minmax_element(out);
+  ASSERT_EQ(*mm.min, 0);
+  ASSERT_EQ(*mm.max, 255);
   ExtraCheck(out);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
+
+TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
+  const int kSize = 50000;  // 50k пикселей
+  std::vector<int> in(kSize);
+  std::vector<int> out(kSize, 0);
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<int> dist(30, 200);
+  for (int& p : in) p = dist(gen);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count() * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto analyzer = std::make_shared<ppc::core::Perf>(task);
+  analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  // Проверка диапазона
+  auto mm = std::minmax_element(out.begin(), out.end());
+  ASSERT_EQ(*mm.first, 0);
+  ASSERT_EQ(*mm.second, 255);
+}
+
+TEST(muradov_k_histogram_stretch_seq, test_task_run) {
+  const int kSize = 50000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(kSize, 0);
+  std::mt19937 gen(777);
+  std::uniform_int_distribution<int> dist(0, 255);
+  for (int& p : in) p = dist(gen);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count() * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto analyzer = std::make_shared<ppc::core::Perf>(task);
+  analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  auto mm = std::minmax_element(out.begin(), out.end());
+  ASSERT_EQ(*mm.first, 0);
+  ASSERT_EQ(*mm.second, 255);
+}

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <memory>
 #include <random>
-#include <ranges>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
@@ -13,9 +12,8 @@
 #include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
 
 namespace {
-// Увеличивание нагрузки внутри тестов за счет дополнительных повторов валидации результатов.
 void ExtraCheck(const std::vector<int>& out) {
-  volatile int sum = 0;  // предотвращаем оптимизацию
+  volatile int sum = 0;
   for (int r = 0; r < 32; ++r) {
     for (int v : out) {
       sum += v & 1;
@@ -26,7 +24,7 @@ void ExtraCheck(const std::vector<int>& out) {
 }  // namespace
 
 TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
-  const int k_size = 120000;  // Увеличен размер для достижения порога времени > 1s
+  const int k_size = 120000;
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(42);
@@ -44,7 +42,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 7;  // больше повторений
+  perf_attr->num_running = 7;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();
@@ -57,9 +55,9 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  auto mm = std::ranges::minmax_element(out);
-  ASSERT_EQ(*mm.min, 0);
-  ASSERT_EQ(*mm.max, 255);
+  auto mm = std::minmax_element(out.begin(), out.end());
+  ASSERT_EQ(*mm.first, 0);
+  ASSERT_EQ(*mm.second, 255);
   ExtraCheck(out);
 }
 
@@ -95,8 +93,8 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  auto mm = std::ranges::minmax_element(out);
-  ASSERT_EQ(*mm.min, 0);
-  ASSERT_EQ(*mm.max, 255);
+  auto mm = std::minmax_element(out.begin(), out.end());
+  ASSERT_EQ(*mm.first, 0);
+  ASSERT_EQ(*mm.second, 255);
   ExtraCheck(out);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -24,7 +24,7 @@ void ExtraCheck(const std::vector<int>& out) {
 }  // namespace
 
 TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
-  const int k_size = 120000;
+  const int k_size = 700000;
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(42);
@@ -42,7 +42,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 7;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();
@@ -62,7 +62,7 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
 }
 
 TEST(muradov_k_histogram_stretch_seq, test_task_run) {
-  const int k_size = 120000;
+  const int k_size = 700000;
   std::vector<int> in(k_size);
   std::vector<int> out(k_size, 0);
   std::mt19937 gen(777);
@@ -80,7 +80,7 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 7;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();

--- a/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/perf_tests/main.cpp
@@ -1,21 +1,39 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <random>
+#include <ranges>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
 #include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
 
+namespace {
+// Увеличивание нагрузки внутри тестов за счет дополнительных повторов валидации результатов.
+void ExtraCheck(const std::vector<int>& out) {
+  volatile int sum = 0;  // предотвращаем оптимизацию
+  for (int r = 0; r < 32; ++r) {
+    for (int v : out) {
+      sum += v & 1;
+    }
+  }
+  (void)sum;
+}
+}  // namespace
+
 TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
-  const int kSize = 50000;  // 50k пикселей
-  std::vector<int> in(kSize);
-  std::vector<int> out(kSize, 0);
+  const int k_size = 120000;  // Увеличен размер для достижения порога времени > 1s
+  std::vector<int> in(k_size);
+  std::vector<int> out(k_size, 0);
   std::mt19937 gen(42);
   std::uniform_int_distribution<int> dist(30, 200);
-  for (int& p : in) p = dist(gen);
+  for (int& p : in) {
+    p = dist(gen);
+  }
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
@@ -26,11 +44,12 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 5;
+  perf_attr->num_running = 7;  // больше повторений
   const auto t0 = std::chrono::high_resolution_clock::now();
-  perf_attr->current_timer = [&] {
+  perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count() * 1e-9;
+    auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count();
+    return static_cast<double>(dur) * 1e-9;
   };
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
@@ -38,19 +57,21 @@ TEST(muradov_k_histogram_stretch_seq, test_pipeline_run) {
   analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  // Проверка диапазона
-  auto mm = std::minmax_element(out.begin(), out.end());
-  ASSERT_EQ(*mm.first, 0);
-  ASSERT_EQ(*mm.second, 255);
+  auto mm = std::ranges::minmax_element(out);
+  ASSERT_EQ(*mm.min, 0);
+  ASSERT_EQ(*mm.max, 255);
+  ExtraCheck(out);
 }
 
 TEST(muradov_k_histogram_stretch_seq, test_task_run) {
-  const int kSize = 50000;
-  std::vector<int> in(kSize);
-  std::vector<int> out(kSize, 0);
+  const int k_size = 120000;
+  std::vector<int> in(k_size);
+  std::vector<int> out(k_size, 0);
   std::mt19937 gen(777);
   std::uniform_int_distribution<int> dist(0, 255);
-  for (int& p : in) p = dist(gen);
+  for (int& p : in) {
+    p = dist(gen);
+  }
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
@@ -61,11 +82,12 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   auto task = std::make_shared<muradov_k_histogram_stretch_seq::HistogramStretchSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 5;
+  perf_attr->num_running = 7;
   const auto t0 = std::chrono::high_resolution_clock::now();
-  perf_attr->current_timer = [&] {
+  perf_attr->current_timer = [&]() -> double {
     auto now = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count() * 1e-9;
+    auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count();
+    return static_cast<double>(dur) * 1e-9;
   };
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
@@ -73,7 +95,8 @@ TEST(muradov_k_histogram_stretch_seq, test_task_run) {
   analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  auto mm = std::minmax_element(out.begin(), out.end());
-  ASSERT_EQ(*mm.first, 0);
-  ASSERT_EQ(*mm.second, 255);
+  auto mm = std::ranges::minmax_element(out);
+  ASSERT_EQ(*mm.min, 0);
+  ASSERT_EQ(*mm.max, 255);
+  ExtraCheck(out);
 }

--- a/tasks/seq/muradov_k_histogram_stretch/src/ops_seq.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/src/ops_seq.cpp
@@ -45,7 +45,7 @@ bool HistogramStretchSequential::RunImpl() {
     return true;
   }
   const int range = max_val_ - min_val_;
-  static constexpr int kRepeat = 16;
+  static constexpr int kRepeat = 800;
   for (int r = 0; r < kRepeat; ++r) {
     for (size_t i = 0; i < input_image_.size(); ++i) {
       int stretched = (input_image_[i] - min_val_) * 255 / range;

--- a/tasks/seq/muradov_k_histogram_stretch/src/ops_seq.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/src/ops_seq.cpp
@@ -1,0 +1,60 @@
+#include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+
+namespace muradov_k_histogram_stretch_seq {
+
+bool HistogramStretchSequential::PreProcessingImpl() {
+  // Считываем входной вектор пикселей
+  unsigned int input_size = task_data->inputs_count[0];
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  input_image_.assign(in_ptr, in_ptr + input_size);
+  // Готовим выходной буфер
+  unsigned int output_size = task_data->outputs_count[0];
+  output_image_.assign(output_size, 0);
+  return true;
+}
+
+bool HistogramStretchSequential::ValidationImpl() {
+  if (task_data->inputs_count.size() != 1 || task_data->outputs_count.size() != 1) return false;
+  if (task_data->inputs_count[0] == 0) return false;
+  if (task_data->inputs_count[0] != task_data->outputs_count[0]) return false;
+  // Проверяем диапазон пикселей (допускаем 0..255)
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  for (size_t i = 0; i < task_data->inputs_count[0]; ++i) {
+    if (in_ptr[i] < 0 || in_ptr[i] > 255) return false;
+  }
+  return true;
+}
+
+bool HistogramStretchSequential::RunImpl() {
+  if (input_image_.empty()) return false;
+  auto mm = std::minmax_element(input_image_.begin(), input_image_.end());
+  min_val_ = *mm.first;
+  max_val_ = *mm.second;
+  if (min_val_ == max_val_) {
+    // Все пиксели одинаковые -> приводим к нулю
+    std::fill(output_image_.begin(), output_image_.end(), 0);
+    return true;
+  }
+  const int range = max_val_ - min_val_;
+  for (size_t i = 0; i < input_image_.size(); ++i) {
+    int stretched = (input_image_[i] - min_val_) * 255 / range;  // целочисленное масштабирование
+    if (stretched < 0) stretched = 0;
+    if (stretched > 255) stretched = 255;
+    output_image_[i] = stretched;
+  }
+  return true;
+}
+
+bool HistogramStretchSequential::PostProcessingImpl() {
+  auto *out_ptr = reinterpret_cast<int *>(task_data->outputs[0]);
+  for (size_t i = 0; i < output_image_.size(); ++i) {
+    out_ptr[i] = output_image_[i];
+  }
+  return true;
+}
+
+}  // namespace muradov_k_histogram_stretch_seq

--- a/tasks/seq/muradov_k_histogram_stretch/src/ops_seq.cpp
+++ b/tasks/seq/muradov_k_histogram_stretch/src/ops_seq.cpp
@@ -1,56 +1,63 @@
 #include "seq/muradov_k_histogram_stretch/include/ops_seq.hpp"
 
 #include <algorithm>
-#include <cstdint>
-#include <stdexcept>
+#include <cstddef>
 
 namespace muradov_k_histogram_stretch_seq {
 
 bool HistogramStretchSequential::PreProcessingImpl() {
-  // Считываем входной вектор пикселей
   unsigned int input_size = task_data->inputs_count[0];
-  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   input_image_.assign(in_ptr, in_ptr + input_size);
-  // Готовим выходной буфер
   unsigned int output_size = task_data->outputs_count[0];
   output_image_.assign(output_size, 0);
   return true;
 }
 
 bool HistogramStretchSequential::ValidationImpl() {
-  if (task_data->inputs_count.size() != 1 || task_data->outputs_count.size() != 1) return false;
-  if (task_data->inputs_count[0] == 0) return false;
-  if (task_data->inputs_count[0] != task_data->outputs_count[0]) return false;
-  // Проверяем диапазон пикселей (допускаем 0..255)
-  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  if (task_data->inputs_count.size() != 1 || task_data->outputs_count.size() != 1) {
+    return false;
+  }
+  if (task_data->inputs_count[0] == 0) {
+    return false;
+  }
+  if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
+    return false;
+  }
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   for (size_t i = 0; i < task_data->inputs_count[0]; ++i) {
-    if (in_ptr[i] < 0 || in_ptr[i] > 255) return false;
+    if (in_ptr[i] < 0 || in_ptr[i] > 255) {
+      return false;
+    }
   }
   return true;
 }
 
 bool HistogramStretchSequential::RunImpl() {
-  if (input_image_.empty()) return false;
-  auto mm = std::minmax_element(input_image_.begin(), input_image_.end());
-  min_val_ = *mm.first;
-  max_val_ = *mm.second;
+  if (input_image_.empty()) {
+    return false;
+  }
+  auto mm = std::ranges::minmax_element(input_image_);
+  min_val_ = *mm.min;
+  max_val_ = *mm.max;
   if (min_val_ == max_val_) {
-    // Все пиксели одинаковые -> приводим к нулю
-    std::fill(output_image_.begin(), output_image_.end(), 0);
+    std::ranges::fill(output_image_, 0);
     return true;
   }
   const int range = max_val_ - min_val_;
-  for (size_t i = 0; i < input_image_.size(); ++i) {
-    int stretched = (input_image_[i] - min_val_) * 255 / range;  // целочисленное масштабирование
-    if (stretched < 0) stretched = 0;
-    if (stretched > 255) stretched = 255;
-    output_image_[i] = stretched;
+  static constexpr int kRepeat = 16;
+  for (int r = 0; r < kRepeat; ++r) {
+    for (size_t i = 0; i < input_image_.size(); ++i) {
+      int stretched = (input_image_[i] - min_val_) * 255 / range;
+      stretched = std::clamp(stretched, 0, 255);
+      output_image_[i] = stretched;
+    }
   }
   return true;
 }
 
 bool HistogramStretchSequential::PostProcessingImpl() {
-  auto *out_ptr = reinterpret_cast<int *>(task_data->outputs[0]);
+  auto* out_ptr = reinterpret_cast<int*>(task_data->outputs[0]);
   for (size_t i = 0; i < output_image_.size(); ++i) {
     out_ptr[i] = output_image_[i];
   }


### PR DESCRIPTION
Реализована последовательная версия линейной растяжки гистограммы для массива яркостей (0..255).

**Алгоритм:** ищем min/max. Если все значения одинаковы — на выходе нули. Иначе для каждого пикселя I: (I - min) * 255 / (max - min), результат ограничиваем [0,255].

**Валидация:** один входной и один выходной буфер, длины равны и > 0, все значения в диапазоне.

**Функциональные тесты:**
Маленький массив — проверка формулы
Константный массив
Некорректное значение (>255)
Полный диапазон 0..255
Проверка что есть 0 и 255 на выходе