### PR TITLE
[ПЕРЕСДАЧА] Частов Вячеслав Робертович 3822Б1ФИ2 OMP

### DIFF
--- a/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/func_tests/main.cpp
+++ b/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,435 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/chastov_v_shell_sort_with_even_odd_batcher_merge/include/ops_omp.hpp"
+
+namespace {
+std::vector<int> GenerateRandomArray(int array_size, std::pair<int, int> value_range) {
+  if (array_size <= 0) {
+    throw std::invalid_argument("Invalid array size");
+  }
+
+  std::random_device random_seed;
+  std::mt19937 random_engine(random_seed());
+  std::uniform_int_distribution<int> value_distribution(value_range.first, value_range.second);
+
+  std::vector<int> random_array;
+  random_array.reserve(array_size);
+  for (int i = 0; i < array_size; i++) {
+    random_array.push_back(value_distribution(random_engine));
+  }
+  return random_array;
+}
+}  // namespace
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_positive_values) {
+  // Create data
+  std::vector<int> in = {300, 246, 1253, 67, 8, 900, 3421, 1, 10, 1223445};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_negative_values) {
+  // Create data
+  std::vector<int> in = {-300, -246, -1253, -67, -8, -900, -3421, -1, -10, -1223445};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_repeating_value) {
+  // Create data
+  std::vector<int> in = {10, 10, 8, 9399, 10, 10, 546, 2387, 3728};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_sorted_values) {
+  // Create data
+  std::vector<int> in = {1, 2, 3, 10, 30, 60, 1500, 3000, 15000};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_reverse_sorted_array) {
+  // Create data
+  std::vector<int> in = {15000, 3000, 5678, 1500, 60, 30, 10, 3, 2, 1};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_single_element) {
+  // Create data
+  std::vector<int> in = {42};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_two_elements) {
+  // Create data
+  std::vector<int> in = {2, 1};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_mixed_positive_negative) {
+  // Create data
+  std::vector<int> in = {-5, 3, -2, 0, 7, -1, 4};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_all_identical) {
+  // Create data
+  std::vector<int> in = {5, 5, 5, 5, 5, 5, 5};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_large_random) {
+  // Create data
+  const int array_size = 1000;
+  const int max_value = 1000;
+  const int min_value = -1000;
+
+  std::vector<int> in = GenerateRandomArray(array_size, {min_value, max_value});
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_zero_values) {
+  // Create data
+  std::vector<int> in = {0, 0, 0, 0, 0, 0};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_duplicates_sorted_forward) {
+  // Create data
+  std::vector<int> in = {1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_duplicates_sorted_reverse) {
+  // Create data
+  std::vector<int> in = {5, 5, 4, 4, 3, 3, 2, 2, 1, 1};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_duplicates_mixed_order) {
+  // Create data
+  std::vector<int> in = {3, 1, 2, 3, 1, 2, 3, 1, 2};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_duplicates_with_extremes) {
+  // Create data
+  std::vector<int> in = {INT_MAX, INT_MIN, 0, INT_MAX, INT_MIN, 0, INT_MAX, INT_MIN, 0};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge, test_multiple_duplicates_random) {
+  // Create data
+  std::vector<int> in;
+  in.reserve(60);
+
+  for (int i = 0; i < 10; ++i) {
+    in.push_back(i);
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 10; ++j) {
+      in.push_back(j);
+    }
+  }
+
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(in.begin(), in.end(), g);
+
+  std::vector<int> out(in.size(), 0);
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(ref, out);
+}

--- a/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/include/ops_omp.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace chastov_v_shell_sort_with_even_odd_batcher_merge {
+
+class TestTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_data_;
+};
+
+}  // namespace chastov_v_shell_sort_with_even_odd_batcher_merge

--- a/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/chastov_v_shell_sort_with_even_odd_batcher_merge/include/ops_omp.hpp"
+
+namespace {
+std::vector<int> GenerateRandomArray(int array_size, std::pair<int, int> value_range) {
+  if (array_size <= 0) {
+    throw std::invalid_argument("Invalid array size");
+  }
+
+  std::random_device random_seed;
+  std::mt19937 random_engine(random_seed());
+  std::uniform_int_distribution<int> value_distribution(value_range.first, value_range.second);
+
+  std::vector<int> random_array;
+  random_array.reserve(array_size);
+  for (int i = 0; i < array_size; i++) {
+    random_array.push_back(value_distribution(random_engine));
+  }
+  return random_array;
+}
+}  // namespace
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge_omp, test_pipeline_run) {
+  const int max_range_value = 1000;
+  const int min_range_value = -1000;
+  const int size = 150000;
+
+  bool descending_flag = false;
+
+  std::vector<int> in = GenerateRandomArray(size, {min_range_value, max_range_value});
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected_result = in;
+  std::ranges::sort(expected_result);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&descending_flag));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected_result, out);
+}
+
+TEST(chastov_v_shell_sort_with_even_odd_batcher_merge_omp, test_task_run) {
+  const int max_range_value = 1000;
+  const int min_range_value = -1000;
+  const int size = 300000;
+
+  bool descending_flag = false;
+
+  // Create data
+  std::vector<int> in = GenerateRandomArray(size, {min_range_value, max_range_value});
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected_result = in;
+  std::ranges::sort(expected_result);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&descending_flag));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected_result, out);
+}

--- a/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/chastov_v_shell_sort_with_even_odd_batcher_merge/src/ops_omp.cpp
@@ -1,0 +1,161 @@
+#include "omp/chastov_v_shell_sort_with_even_odd_batcher_merge/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <vector>
+
+namespace {
+
+std::vector<size_t> ComputeGapSequence(int n) {
+  std::vector<size_t> step_sizes;
+  int k = 0;
+
+  while (true) {
+    int step_size = 0;
+    if (k % 2 == 0) {
+      step_size = 9 * (1 << (2 * k)) - 9 * (1 << k) + 1;
+    } else {
+      step_size = 8 * (1 << k) - 6 * (1 << ((k + 1) / 2)) + 1;
+    }
+
+    if (step_size > n / 2) {
+      break;
+    }
+
+    step_sizes.push_back(static_cast<size_t>(step_size));
+    k = k + 1;
+  }
+
+  if (step_sizes.empty() || step_sizes.back() != 1) {
+    step_sizes.push_back(1);
+  }
+
+  std::ranges::reverse(step_sizes.begin(), step_sizes.end());
+  return step_sizes;
+}
+
+void BatcherMerge(std::vector<int> &data, size_t begin, size_t center, size_t finish) {
+  auto begin_iter = std::next(data.begin(), static_cast<std::ptrdiff_t>(begin));
+  auto center_iter = std::next(data.begin(), static_cast<std::ptrdiff_t>(center));
+  auto finish_iter = std::next(data.begin(), static_cast<std::ptrdiff_t>(finish));
+
+  std::vector<int> left(begin_iter, center_iter);
+  std::vector<int> right(center_iter, finish_iter);
+
+  size_t l_pos = 0;
+  size_t r_pos = 0;
+  size_t position = begin;
+
+  size_t l_length = center - begin;
+  size_t r_length = finish - center;
+
+  for (size_t i = begin; i < finish; i++) {
+    if (i % 2 == 0) {
+      if (l_pos < l_length && (r_pos >= r_length || left[l_pos] <= right[r_pos])) {
+        data[position] = left[l_pos];
+        position++;
+        l_pos++;
+      } else {
+        data[position] = right[r_pos];
+        position++;
+        r_pos++;
+      }
+    } else {
+      if (r_pos < r_length && (l_pos >= l_length || right[r_pos] <= left[l_pos])) {
+        data[position] = right[r_pos];
+        position++;
+        r_pos++;
+      } else {
+        data[position] = left[l_pos];
+        position++;
+        l_pos++;
+      }
+    }
+  }
+}
+
+void EnhancedShellSort(std::vector<int> &data) {
+  size_t total_elements = data.size();
+  if (total_elements <= 1) {
+    return;
+  }
+
+  int threads_count = omp_get_max_threads();
+  size_t chunk_size = (total_elements + threads_count - 1) / threads_count;
+
+#pragma omp parallel
+  {
+    int thread_idx = omp_get_thread_num();
+
+    size_t chunk_begin = static_cast<size_t>(thread_idx) * chunk_size;
+    size_t chunk_end = std::min(chunk_begin + chunk_size, total_elements) - 1;
+
+    if (chunk_begin < total_elements) {
+      auto local_size = static_cast<int>(chunk_end - chunk_begin + 1);
+      auto step_sizes = ComputeGapSequence(local_size);
+
+      for (size_t step_size : step_sizes) {
+        for (size_t i = chunk_begin + step_size; i <= chunk_end; i++) {
+          int tmp = data[i];
+          size_t j = i;
+          while (j >= chunk_begin + step_size && data[j - step_size] > tmp) {
+            data[j] = data[j - step_size];
+            j -= step_size;
+          }
+          data[j] = tmp;
+        }
+      }
+    }
+  }
+
+  for (size_t merge_size = chunk_size; merge_size < total_elements; merge_size *= 2) {
+#pragma omp parallel for schedule(static)
+    for (int k = 0; k < static_cast<int>(total_elements); k += static_cast<int>(2 * merge_size)) {
+      size_t center = std::min(k + merge_size, total_elements);
+      size_t finish = std::min(k + (2 * merge_size), total_elements);
+      if (center < finish) {
+        BatcherMerge(data, k, center, finish);
+      }
+    }
+  }
+}
+}  // namespace
+
+bool chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP::PreProcessingImpl() {
+  size_t data_count = task_data->inputs_count[0];
+  uint8_t *input_buffer = task_data->inputs[0];
+
+  input_data_.clear();
+  input_data_.reserve(data_count);
+
+  for (size_t i = 0; i < data_count; ++i) {
+    int value = *reinterpret_cast<int *>(input_buffer + (i * sizeof(int)));
+    input_data_.push_back(value);
+  }
+
+  return true;
+}
+
+bool chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP::ValidationImpl() {
+  return task_data->inputs_count[0] > 0 && task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP::RunImpl() {
+  EnhancedShellSort(input_data_);
+  return true;
+}
+
+bool chastov_v_shell_sort_with_even_odd_batcher_merge::TestTaskOpenMP::PostProcessingImpl() {
+  int *output_destination = reinterpret_cast<int *>(task_data->outputs[0]);
+  size_t output_size = task_data->outputs_count[0];
+
+  for (size_t i = 0; i < output_size; ++i) {
+    output_destination[i] = input_data_[i];
+  }
+
+  return true;
+}


### PR DESCRIPTION
16 вариант - Сортировка Шелла с четно-нечетным слиянием Бэтчера.

Реализована параллельная версия алгоритма сортировки Шелла, объединенная с четно-нечетным слиянием Бэтчера для эффективного объединения отсортированных подмассивов. Алгоритм использует многопоточность через OpenMP для ускорения обработки данных.