### PR TITLE
[ПЕРЕСДАЧА] Кошкин Никита Александрович 3822Б1ФИ3 OMP

### DIFF
--- a/tasks/omp/koshkin_n_convex_hull_binary_image/func_tests/main.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/func_tests/main.cpp
@@ -23,15 +23,15 @@ TEST(koshkin_n_convex_hull_binary_image_omp, small_4x4) {
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
 
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
-  task_data_seq->inputs_count.emplace_back(width);
-  task_data_seq->inputs_count.emplace_back(height);
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
 
-  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_omp);
   ASSERT_EQ(test_task_omp.Validation(), true);
   test_task_omp.PreProcessing();
   test_task_omp.Run();
@@ -57,15 +57,15 @@ TEST(koshkin_n_convex_hull_binary_image_omp, small_5x5) {
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{0, 0}, {0, 4}, {4, 0}, {4, 4}};
 
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
-  task_data_seq->inputs_count.emplace_back(width);
-  task_data_seq->inputs_count.emplace_back(height);
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
 
-  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_omp);
   ASSERT_EQ(test_task_omp.Validation(), true);
   test_task_omp.PreProcessing();
   test_task_omp.Run();
@@ -88,15 +88,15 @@ TEST(koshkin_n_convex_hull_binary_image_omp, medium_4x8) {
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{1, 1}, {1, 2}, {3, 1}, {5, 2}};
 
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
-  task_data_seq->inputs_count.emplace_back(width);
-  task_data_seq->inputs_count.emplace_back(height);
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
 
-  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_omp);
   ASSERT_EQ(test_task_omp.Validation(), true);
   test_task_omp.PreProcessing();
   test_task_omp.Run();
@@ -114,15 +114,15 @@ TEST(koshkin_n_convex_hull_binary_image_omp, collinear_horizontal_line) {
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{0, 0}, {4, 0}};
 
   std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
-  task_data_seq->inputs_count.emplace_back(width);
-  task_data_seq->inputs_count.emplace_back(height);
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
 
-  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_omp);
   ASSERT_EQ(test_task_omp.Validation(), true);
   test_task_omp.PreProcessing();
   test_task_omp.Run();

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/func_tests/main.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/func_tests/main.cpp
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 #include <omp.h>
 
-#include <algorithm>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <vector>
 

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/func_tests/main.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/func_tests/main.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+#include <omp.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/koshkin_n_convex_hull_binary_image/include/ops_omp.hpp"
+
+TEST(koshkin_n_convex_hull_binary_image_omp, small_4x4) {
+  int height = 4;
+  int width = 4;
+
+  std::vector<int> image = {0, 0, 0, 0,
+
+                            0, 1, 1, 0,
+
+                            0, 1, 1, 0,
+
+                            0, 0, 0, 0};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(out, exp);
+}
+
+TEST(koshkin_n_convex_hull_binary_image_omp, small_5x5) {
+  int height = 5;
+  int width = 5;
+
+  std::vector<int> image = {1, 1, 1, 1, 1,
+
+                            1, 0, 0, 0, 1,
+
+                            1, 0, 0, 0, 1,
+
+                            1, 0, 0, 0, 1,
+
+                            1, 1, 1, 1, 1};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{0, 0}, {0, 4}, {4, 0}, {4, 4}};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(out, exp);
+}
+
+TEST(koshkin_n_convex_hull_binary_image_omp, medium_4x8) {
+  int height = 4;
+  int width = 8;
+
+  std::vector<int> image = {0, 0, 0, 0, 0, 0, 0, 0,
+
+                            0, 1, 1, 1, 0, 0, 0, 0,
+
+                            0, 1, 0, 1, 1, 1, 0, 0,
+
+                            0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{1, 1}, {1, 2}, {3, 1}, {5, 2}};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(out, exp);
+}
+
+TEST(koshkin_n_convex_hull_binary_image_omp, collinear_horizontal_line) {
+  int height = 1;
+  int width = 5;
+
+  std::vector<int> image = {1, 1, 1, 1, 1};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{0, 0}, {4, 0}};
+
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(image.data()));
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage test_task_omp(task_data_seq);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(out, exp);
+}

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/include/ops_omp.hpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/include/ops_omp.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace koshkin_n_convex_hull_binary_image_omp {
+using Pt = std::pair<int, int>;
+class ConvexHullBinaryImage : public ppc::core::Task {
+ public:
+  explicit ConvexHullBinaryImage(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  static long long Cross(const Pt& a, const Pt& b, const Pt& c);
+  static inline bool IsBorderPixel(const std::vector<int>& in, int width, int height, int x, int y);
+  static long long Dist2(const Pt& a, const Pt& b);
+
+  void FindPoints();
+  std::vector<int> input_;
+  std::vector<Pt> points_;
+  std::vector<Pt> output_;
+  int width_{}, height_{};
+};
+}  // namespace koshkin_n_convex_hull_binary_image_omp

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/perf_tests/main.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/perf_tests/main.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/perf_tests/main.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/perf_tests/main.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/koshkin_n_convex_hull_binary_image/include/ops_omp.hpp"
+
+TEST(koshkin_n_shell_sort_batchers_even_odd_merge_omp, test_pipeline_run) {
+  // Create data
+  int sz = 8500;
+
+  std::vector<int> in(sz * sz, 1);
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{0, 0}, {0, sz - 1}, {sz - 1, 0}, {sz - 1, sz - 1}};
+
+  // Create task_data
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(sz);
+  task_data_omp->inputs_count.emplace_back(sz);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(out, exp);
+}
+
+TEST(koshkin_n_shell_sort_batchers_even_odd_merge_omp, test_task_run) {
+  // Create data
+  int sz = 8500;
+
+  std::vector<int> in(sz * sz, 1);
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> exp = {{0, 0}, {0, sz - 1}, {sz - 1, 0}, {sz - 1, sz - 1}};
+
+  // Create task_data
+  std::vector<koshkin_n_convex_hull_binary_image_omp::Pt> out(exp.size());
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(sz);
+  task_data_omp->inputs_count.emplace_back(sz);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(out, exp);
+}

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/src/ops_omp.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/src/ops_omp.cpp
@@ -1,0 +1,196 @@
+#include "omp/koshkin_n_convex_hull_binary_image/include/ops_omp.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+bool koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::PreProcessingImpl() {
+  width_ = static_cast<int>(task_data->inputs_count[0]);
+  height_ = static_cast<int>(task_data->inputs_count[1]);
+  unsigned int size = static_cast<unsigned int>(width_) * static_cast<unsigned int>(height_);
+
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + size);
+
+  return true;
+}
+
+bool koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::ValidationImpl() {
+  return task_data->inputs_count[0] > 0 && task_data->inputs_count[1] > 0;
+}
+
+long long koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::Cross(const Pt& a, const Pt& b, const Pt& c) {
+  long long bax = static_cast<long long>(b.first) - a.first;
+  long long bay = static_cast<long long>(b.second) - a.second;
+  long long cax = static_cast<long long>(c.first) - a.first;
+  long long cay = static_cast<long long>(c.second) - a.second;
+  return (bax * cay) - (bay * cax);
+}
+
+long long koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::Dist2(const Pt& a, const Pt& b) {
+  long long dx = static_cast<long long>(a.first) - b.first;
+  long long dy = static_cast<long long>(a.second) - b.second;
+  return (dx * dx) + (dy * dy);
+}
+
+inline bool koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::IsBorderPixel(const std::vector<int>& in,
+                                                                                         int width, int height, int x,
+                                                                                         int y) {
+  int row_off = y * width;
+  if (in[row_off + x] != 1) {
+    return false;
+  }
+
+  static const int kDx[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
+  static const int kDy[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
+
+  if (x == 0 || y == 0 || x == width - 1 || y == height - 1) {
+    return true;
+  }
+
+  for (int k = 0; k < 8; ++k) {
+    int nx = x + kDx[k];
+    int ny = y + kDy[k];
+    if (nx < 0 || ny < 0 || nx >= width || ny >= height) {
+      return true;
+    }
+    if (in[(ny * width) + nx] == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::FindPoints() {
+  points_.clear();
+
+  if (width_ <= 0 || height_ <= 0) {
+    return;
+  }
+
+  const int w = width_;
+  const int h = height_;
+
+  int nthreads = 1;
+#ifdef _OPENMP
+  nthreads = omp_get_max_threads();
+#endif
+  if (nthreads < 1) nthreads = 1;
+
+  std::vector<std::vector<Pt>> local_points(static_cast<size_t>(nthreads));
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+  {
+    int tid = 0;
+#ifdef _OPENMP
+    tid = omp_get_thread_num();
+#endif
+    auto& local = local_points[static_cast<size_t>(tid)];
+    local.reserve(256);
+
+#ifdef _OPENMP
+#pragma omp for schedule(static)
+#endif
+    for (int y = 0; y < h; ++y) {
+      int row_off = y * w;
+      for (int x = 0; x < w; ++x) {
+        if (input_[row_off + x] != 1) continue;
+        if (IsBorderPixel(input_, w, h, x, y)) {
+          local.emplace_back(x, y);
+        }
+      }
+    }
+  }
+
+  size_t total = 0;
+  for (auto& vec : local_points) total += vec.size();
+  points_.reserve(total);
+  for (auto& vec : local_points) {
+    if (!vec.empty()) {
+      points_.insert(points_.end(), vec.begin(), vec.end());
+    }
+  }
+}
+
+bool koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::RunImpl() {
+  FindPoints();
+
+  if (points_.empty()) {
+    output_.clear();
+    return true;
+  }
+
+  std::ranges::sort(points_, [](const Pt& a, const Pt& b) {
+    return (a.first < b.first) || (a.first == b.first && a.second < b.second);
+  });
+
+  auto uniq_range = std::ranges::unique(points_);
+  points_.erase(uniq_range.begin(), uniq_range.end());
+
+  if (points_.size() < 3) {
+    output_ = points_;
+    return true;
+  }
+
+  Pt pivot = points_[0];
+  for (const Pt& p : points_) {
+    if (p.second < pivot.second || (p.second == pivot.second && p.first < pivot.first)) {
+      pivot = p;
+    }
+  }
+
+  std::ranges::sort(points_, [&](const Pt& a, const Pt& b) {
+    if (a == b) {
+      return false;
+    }
+    long long cr = Cross(pivot, a, b);
+    if (cr != 0) {
+      return cr > 0;
+    }
+    return Dist2(pivot, a) < Dist2(pivot, b);
+  });
+
+  // Build hull (Graham scan)
+  std::vector<Pt> hull;
+  hull.reserve(points_.size());
+  for (const Pt& p : points_) {
+    while (hull.size() >= 2) {
+      Pt q = hull[hull.size() - 2];
+      Pt r = hull[hull.size() - 1];
+      long long cr = Cross(q, r, p);
+      if (cr <= 0) {
+        hull.pop_back();
+      } else {
+        break;
+      }
+    }
+    hull.push_back(p);
+  }
+
+  if (hull.size() == 1 && points_.size() > 1) {
+    hull.push_back(points_.back());
+  }
+
+  output_ = std::move(hull);
+  return true;
+}
+
+bool koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::PostProcessingImpl() {
+  std::ranges::sort(output_, [](const Pt& a, const Pt& b) {
+    return (a.first < b.first) || (a.first == b.first && a.second < b.second);
+  });
+
+  Pt* dest = reinterpret_cast<Pt*>(task_data->outputs[0]);
+  std::copy_n(output_.begin(), output_.size(), dest);
+  task_data->outputs_count[0] = static_cast<int>(output_.size());
+  return true;
+}

--- a/tasks/omp/koshkin_n_convex_hull_binary_image/src/ops_omp.cpp
+++ b/tasks/omp/koshkin_n_convex_hull_binary_image/src/ops_omp.cpp
@@ -1,10 +1,8 @@
 #include "omp/koshkin_n_convex_hull_binary_image/include/ops_omp.hpp"
 
 #include <algorithm>
-#include <cstdint>
-#include <iostream>
-#include <memory>
-#include <random>
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #ifdef _OPENMP
@@ -82,7 +80,7 @@ void koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::FindPoints()
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #endif
-  if (nthreads < 1) nthreads = 1;
+  nthreads = std::max(1, nthreads);
 
   std::vector<std::vector<Pt>> local_points(static_cast<size_t>(nthreads));
 
@@ -103,7 +101,9 @@ void koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::FindPoints()
     for (int y = 0; y < h; ++y) {
       int row_off = y * w;
       for (int x = 0; x < w; ++x) {
-        if (input_[row_off + x] != 1) continue;
+        if (input_[row_off + x] != 1) {
+          continue;
+        }
         if (IsBorderPixel(input_, w, h, x, y)) {
           local.emplace_back(x, y);
         }
@@ -112,7 +112,9 @@ void koshkin_n_convex_hull_binary_image_omp::ConvexHullBinaryImage::FindPoints()
   }
 
   size_t total = 0;
-  for (auto& vec : local_points) total += vec.size();
+  for (auto& vec : local_points) {
+    total += vec.size();
+  }
   points_.reserve(total);
   for (auto& vec : local_points) {
     if (!vec.empty()) {


### PR DESCRIPTION
Задача 2. Технология OMP. Вариант 30: Построение выпуклой оболочки для компонент бинарного изображения.

Поскольку для SEQ версии самый тяжёлый и параллелизуемый кусок оказался в функции  FindPoints(), решение её распараллелить - локальные векторы в каждом потоке + единичный merge.