### PR TITLE
[ПЕРЕСДАЧА] Калинин Дмитрий Андреевич 3822Б1ПР2 OMP

### DIFF
--- a/tasks/omp/kalinin_d_simpson_method/func_tests/main.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/func_tests/main.cpp
@@ -169,7 +169,7 @@ TEST(kalinin_d_simpson_method_omp, three_dim_product_unit_cube) {
   int n = 20;
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 2, &res);
-  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
   ASSERT_TRUE(task.Validation());
   task.PreProcessing();
   task.Run();
@@ -183,7 +183,7 @@ TEST(kalinin_d_simpson_method_omp, two_dim_constant_mixed_bounds) {
   int n = 100;
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &res);
-  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
   ASSERT_TRUE(task.Validation());
   task.PreProcessing();
   task.Run();
@@ -197,7 +197,7 @@ TEST(kalinin_d_simpson_method_omp, validation_odd_segments) {
   int n = 11;  // odd -> invalid
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &res);
-  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
   EXPECT_FALSE(task.Validation());
 }
 
@@ -208,7 +208,7 @@ TEST(kalinin_d_simpson_method_omp, four_dim_constant_hyperrectangle) {
   int n = 10;
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &res);
-  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
   ASSERT_TRUE(task.Validation());
   task.PreProcessing();
   task.Run();

--- a/tasks/omp/kalinin_d_simpson_method/func_tests/main.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/func_tests/main.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& low
 
 }  // namespace
 
-TEST(kalinin_d_simpson_method_seq, one_dim_constant) {
+TEST(kalinin_d_simpson_method_omp, one_dim_constant) {
   std::vector<double> a{0.0};
   std::vector<double> b{5.0};
   int n = 100;
@@ -50,7 +50,7 @@ TEST(kalinin_d_simpson_method_seq, one_dim_constant) {
   EXPECT_NEAR(res, 5.0, 1e-9);
 }
 
-TEST(kalinin_d_simpson_method_seq, one_dim_linear) {
+TEST(kalinin_d_simpson_method_omp, one_dim_linear) {
   std::vector<double> a{0.0};
   std::vector<double> b{1.0};
   int n = 100;
@@ -64,7 +64,7 @@ TEST(kalinin_d_simpson_method_seq, one_dim_linear) {
   EXPECT_NEAR(res, 0.5, 1e-9);
 }
 
-TEST(kalinin_d_simpson_method_seq, one_dim_quadratic) {
+TEST(kalinin_d_simpson_method_omp, one_dim_quadratic) {
   std::vector<double> a{0.0};
   std::vector<double> b{1.0};
   int n = 100;
@@ -79,7 +79,7 @@ TEST(kalinin_d_simpson_method_seq, one_dim_quadratic) {
   EXPECT_NEAR(res, 1.0 / 3.0, 1e-9);
 }
 
-TEST(kalinin_d_simpson_method_seq, two_dim_constant_rect) {
+TEST(kalinin_d_simpson_method_omp, two_dim_constant_rect) {
   std::vector<double> a{0.0, 0.0};
   std::vector<double> b{2.0, 3.0};
   int n = 100;
@@ -93,7 +93,7 @@ TEST(kalinin_d_simpson_method_seq, two_dim_constant_rect) {
   EXPECT_NEAR(res, 6.0, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, two_dim_linear_sum_unit_square) {
+TEST(kalinin_d_simpson_method_omp, two_dim_linear_sum_unit_square) {
   std::vector<double> a{0.0, 0.0};
   std::vector<double> b{1.0, 1.0};
   int n = 100;
@@ -107,7 +107,7 @@ TEST(kalinin_d_simpson_method_seq, two_dim_linear_sum_unit_square) {
   EXPECT_NEAR(res, 1.0, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, two_dim_product_unit_square) {
+TEST(kalinin_d_simpson_method_omp, two_dim_product_unit_square) {
   std::vector<double> a{0.0, 0.0};
   std::vector<double> b{1.0, 1.0};
   int n = 100;
@@ -121,7 +121,7 @@ TEST(kalinin_d_simpson_method_seq, two_dim_product_unit_square) {
   EXPECT_NEAR(res, 0.25, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, two_dim_sum_squares_unit_square) {
+TEST(kalinin_d_simpson_method_omp, two_dim_sum_squares_unit_square) {
   std::vector<double> a{0.0, 0.0};
   std::vector<double> b{1.0, 1.0};
   int n = 100;
@@ -135,7 +135,7 @@ TEST(kalinin_d_simpson_method_seq, two_dim_sum_squares_unit_square) {
   EXPECT_NEAR(res, 2.0 / 3.0, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, three_dim_constant_unit_cube) {
+TEST(kalinin_d_simpson_method_omp, three_dim_constant_unit_cube) {
   std::vector<double> a{0.0, 0.0, 0.0};
   std::vector<double> b{1.0, 1.0, 1.0};
   int n = 20;
@@ -149,7 +149,7 @@ TEST(kalinin_d_simpson_method_seq, three_dim_constant_unit_cube) {
   EXPECT_NEAR(res, 1.0, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, three_dim_linear_sum_unit_cube) {
+TEST(kalinin_d_simpson_method_omp, three_dim_linear_sum_unit_cube) {
   std::vector<double> a{0.0, 0.0, 0.0};
   std::vector<double> b{1.0, 1.0, 1.0};
   int n = 20;
@@ -163,13 +163,13 @@ TEST(kalinin_d_simpson_method_seq, three_dim_linear_sum_unit_cube) {
   EXPECT_NEAR(res, 1.5, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, three_dim_product_unit_cube) {
+TEST(kalinin_d_simpson_method_omp, three_dim_product_unit_cube) {
   std::vector<double> a{0.0, 0.0, 0.0};
   std::vector<double> b{1.0, 1.0, 1.0};
   int n = 20;
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 2, &res);
-  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
   ASSERT_TRUE(task.Validation());
   task.PreProcessing();
   task.Run();
@@ -177,13 +177,13 @@ TEST(kalinin_d_simpson_method_seq, three_dim_product_unit_cube) {
   EXPECT_NEAR(res, 0.125, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, two_dim_constant_mixed_bounds) {
+TEST(kalinin_d_simpson_method_omp, two_dim_constant_mixed_bounds) {
   std::vector<double> a{1.0, 2.0};
   std::vector<double> b{3.0, 5.0};
   int n = 100;
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &res);
-  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
   ASSERT_TRUE(task.Validation());
   task.PreProcessing();
   task.Run();
@@ -191,24 +191,24 @@ TEST(kalinin_d_simpson_method_seq, two_dim_constant_mixed_bounds) {
   EXPECT_NEAR(res, 6.0, 1e-8);
 }
 
-TEST(kalinin_d_simpson_method_seq, validation_odd_segments) {
+TEST(kalinin_d_simpson_method_omp, validation_odd_segments) {
   std::vector<double> a{0.0};
   std::vector<double> b{1.0};
   int n = 11;  // odd -> invalid
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &res);
-  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
   EXPECT_FALSE(task.Validation());
 }
 
-TEST(kalinin_d_simpson_method_seq, four_dim_constant_hyperrectangle) {
+TEST(kalinin_d_simpson_method_omp, four_dim_constant_hyperrectangle) {
   std::vector<double> a{0.0, 0.0, -1.0, 2.0};
   std::vector<double> b{1.0, 2.0, 1.0, 4.0};
 
   int n = 10;
   double res = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &res);
-  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  kalinin_d_simpson_method_omp::SimpsonNDSequential task(task_data);
   ASSERT_TRUE(task.Validation());
   task.PreProcessing();
   task.Run();

--- a/tasks/omp/kalinin_d_simpson_method/func_tests/main.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/func_tests/main.cpp
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/kalinin_d_simpson_method/include/ops_omp.hpp"
+
+namespace {
+
+std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& lower, const std::vector<double>& upper,
+                                                  int segments_per_dim, int function_id, double* result_ptr) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  auto* lower_ptr = const_cast<double*>(lower.data());
+  auto* upper_ptr = const_cast<double*>(upper.data());
+
+  static thread_local std::deque<std::array<int, 2>> k_params_storage;
+  k_params_storage.emplace_back(std::array<int, 2>{segments_per_dim, function_id});
+  int* params_ptr = k_params_storage.back().data();
+
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(lower_ptr));
+  task_data->inputs_count.emplace_back(lower.size());
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(upper_ptr));
+  task_data->inputs_count.emplace_back(upper.size());
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(params_ptr));
+  task_data->inputs_count.emplace_back(2);
+
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(result_ptr));
+  task_data->outputs_count.emplace_back(1);
+  return task_data;
+}
+
+}  // namespace
+
+TEST(kalinin_d_simpson_method_seq, one_dim_constant) {
+  std::vector<double> a{0.0};
+  std::vector<double> b{5.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 5.0, 1e-9);
+}
+
+TEST(kalinin_d_simpson_method_seq, one_dim_linear) {
+  std::vector<double> a{0.0};
+  std::vector<double> b{1.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 1, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 0.5, 1e-9);
+}
+
+TEST(kalinin_d_simpson_method_seq, one_dim_quadratic) {
+  std::vector<double> a{0.0};
+  std::vector<double> b{1.0};
+  int n = 100;
+  double res = 0.0;
+
+  auto task_data = MakeTaskData(a, b, n, 3, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 1.0 / 3.0, 1e-9);
+}
+
+TEST(kalinin_d_simpson_method_seq, two_dim_constant_rect) {
+  std::vector<double> a{0.0, 0.0};
+  std::vector<double> b{2.0, 3.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 6.0, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, two_dim_linear_sum_unit_square) {
+  std::vector<double> a{0.0, 0.0};
+  std::vector<double> b{1.0, 1.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 1, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 1.0, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, two_dim_product_unit_square) {
+  std::vector<double> a{0.0, 0.0};
+  std::vector<double> b{1.0, 1.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 2, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 0.25, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, two_dim_sum_squares_unit_square) {
+  std::vector<double> a{0.0, 0.0};
+  std::vector<double> b{1.0, 1.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 3, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 2.0 / 3.0, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, three_dim_constant_unit_cube) {
+  std::vector<double> a{0.0, 0.0, 0.0};
+  std::vector<double> b{1.0, 1.0, 1.0};
+  int n = 20;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 1.0, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, three_dim_linear_sum_unit_cube) {
+  std::vector<double> a{0.0, 0.0, 0.0};
+  std::vector<double> b{1.0, 1.0, 1.0};
+  int n = 20;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 1, &res);
+  kalinin_d_simpson_method_omp::SimpsonNDOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 1.5, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, three_dim_product_unit_cube) {
+  std::vector<double> a{0.0, 0.0, 0.0};
+  std::vector<double> b{1.0, 1.0, 1.0};
+  int n = 20;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 2, &res);
+  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 0.125, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, two_dim_constant_mixed_bounds) {
+  std::vector<double> a{1.0, 2.0};
+  std::vector<double> b{3.0, 5.0};
+  int n = 100;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &res);
+  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 6.0, 1e-8);
+}
+
+TEST(kalinin_d_simpson_method_seq, validation_odd_segments) {
+  std::vector<double> a{0.0};
+  std::vector<double> b{1.0};
+  int n = 11;  // odd -> invalid
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &res);
+  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  EXPECT_FALSE(task.Validation());
+}
+
+TEST(kalinin_d_simpson_method_seq, four_dim_constant_hyperrectangle) {
+  std::vector<double> a{0.0, 0.0, -1.0, 2.0};
+  std::vector<double> b{1.0, 2.0, 1.0, 4.0};
+
+  int n = 10;
+  double res = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &res);
+  kalinin_d_simpson_method_seq::SimpsonNDSequential task(task_data);
+  ASSERT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  EXPECT_NEAR(res, 8.0, 1e-8);
+}

--- a/tasks/omp/kalinin_d_simpson_method/include/ops_omp.hpp
+++ b/tasks/omp/kalinin_d_simpson_method/include/ops_omp.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kalinin_d_simpson_method_omp {
+
+class SimpsonNDOpenMP : public ppc::core::Task {
+ public:
+  explicit SimpsonNDOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  int dimension_{};
+  int segments_per_dim_{};
+  int function_id_{};
+
+  std::vector<double> lower_bounds_;
+  std::vector<double> upper_bounds_;
+
+  double result_{};
+
+  [[nodiscard]] double EvaluateFunction(const std::vector<double>& point) const;
+};
+
+}  // namespace kalinin_d_simpson_method_omp

--- a/tasks/omp/kalinin_d_simpson_method/perf_tests/main.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/perf_tests/main.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& low
 
 }  // namespace
 
-TEST(kalinin_d_simpson_method_seq, perf_pipeline_run_unit_cube_linear_sum) {
+TEST(kalinin_d_simpson_method_omp, perf_pipeline_run_unit_cube_linear_sum) {
   std::vector<double> a{0.0, 0.0, 0.0};
   std::vector<double> b{1.0, 1.0, 1.0};
 
@@ -62,7 +62,7 @@ TEST(kalinin_d_simpson_method_seq, perf_pipeline_run_unit_cube_linear_sum) {
   ASSERT_NEAR(result, 1.5, 1e-6);
 }
 
-TEST(kalinin_d_simpson_method_seq, perf_task_run_hyperrectangle_constant) {
+TEST(kalinin_d_simpson_method_omp, perf_task_run_hyperrectangle_constant) {
   std::vector<double> a{0.0, 0.0, -1.0, 2.0};
   std::vector<double> b{1.0, 2.0, 1.0, 4.0};
   int n = 80;

--- a/tasks/omp/kalinin_d_simpson_method/perf_tests/main.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/perf_tests/main.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/kalinin_d_simpson_method/include/ops_omp.hpp"
+
+namespace {
+
+std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& lower, const std::vector<double>& upper,
+                                                  int segments_per_dim, int function_id, double* result_ptr) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  auto* lower_ptr = const_cast<double*>(lower.data());
+  auto* upper_ptr = const_cast<double*>(upper.data());
+  static thread_local std::deque<std::array<int, 2>> k_params_storage;
+  k_params_storage.emplace_back(std::array<int, 2>{segments_per_dim, function_id});
+  int* params_ptr = k_params_storage.back().data();
+
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(lower_ptr));
+  task_data->inputs_count.emplace_back(lower.size());
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(upper_ptr));
+  task_data->inputs_count.emplace_back(upper.size());
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(params_ptr));
+  task_data->inputs_count.emplace_back(2);
+
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(result_ptr));
+  task_data->outputs_count.emplace_back(1);
+  return task_data;
+}
+
+}  // namespace
+
+TEST(kalinin_d_simpson_method_seq, perf_pipeline_run_unit_cube_linear_sum) {
+  std::vector<double> a{0.0, 0.0, 0.0};
+  std::vector<double> b{1.0, 1.0, 1.0};
+
+  int n = 300;
+  double result = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 1, &result);
+  auto task = std::make_shared<kalinin_d_simpson_method_omp::SimpsonNDOpenMP>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf = std::make_shared<ppc::core::Perf>(task);
+  perf->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_NEAR(result, 1.5, 1e-6);
+}
+
+TEST(kalinin_d_simpson_method_seq, perf_task_run_hyperrectangle_constant) {
+  std::vector<double> a{0.0, 0.0, -1.0, 2.0};
+  std::vector<double> b{1.0, 2.0, 1.0, 4.0};
+  int n = 80;
+  double result = 0.0;
+  auto task_data = MakeTaskData(a, b, n, 0, &result);
+  auto task = std::make_shared<kalinin_d_simpson_method_omp::SimpsonNDOpenMP>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf = std::make_shared<ppc::core::Perf>(task);
+  perf->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_NEAR(result, 8.0, 1e-6);
+}

--- a/tasks/omp/kalinin_d_simpson_method/perf_tests/main.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/perf_tests/main.cpp
@@ -40,7 +40,7 @@ TEST(kalinin_d_simpson_method_omp, perf_pipeline_run_unit_cube_linear_sum) {
   std::vector<double> a{0.0, 0.0, 0.0};
   std::vector<double> b{1.0, 1.0, 1.0};
 
-  int n = 300;
+  int n = 400;
   double result = 0.0;
   auto task_data = MakeTaskData(a, b, n, 1, &result);
   auto task = std::make_shared<kalinin_d_simpson_method_omp::SimpsonNDOpenMP>(task_data);
@@ -65,7 +65,7 @@ TEST(kalinin_d_simpson_method_omp, perf_pipeline_run_unit_cube_linear_sum) {
 TEST(kalinin_d_simpson_method_omp, perf_task_run_hyperrectangle_constant) {
   std::vector<double> a{0.0, 0.0, -1.0, 2.0};
   std::vector<double> b{1.0, 2.0, 1.0, 4.0};
-  int n = 80;
+  int n = 100;
   double result = 0.0;
   auto task_data = MakeTaskData(a, b, n, 0, &result);
   auto task = std::make_shared<kalinin_d_simpson_method_omp::SimpsonNDOpenMP>(task_data);

--- a/tasks/omp/kalinin_d_simpson_method/src/ops_omp.cpp
+++ b/tasks/omp/kalinin_d_simpson_method/src/ops_omp.cpp
@@ -1,0 +1,149 @@
+#include "omp/kalinin_d_simpson_method/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <cmath>
+#include <vector>
+
+namespace kalinin_d_simpson_method_omp {
+namespace {
+double EvaluateById(int id, const std::vector<double>& x) {
+  switch (id) {
+    case 0: {
+      return 1.0;
+    }
+    case 1: {
+      double s = 0.0;
+      for (double v : x) {
+        s += v;
+      }
+      return s;
+    }
+    case 2: {
+      double p = 1.0;
+      for (double v : x) {
+        p *= v;
+      }
+      return p;
+    }
+    case 3: {
+      double s = 0.0;
+      for (double v : x) {
+        s += v * v;
+      }
+      return s;
+    }
+    default:
+      return 0.0;
+  }
+}
+}  // namespace
+
+bool SimpsonNDOpenMP::PreProcessingImpl() {
+  dimension_ = static_cast<int>(task_data->inputs_count[0]);
+  lower_bounds_.assign(reinterpret_cast<double*>(task_data->inputs[0]),
+                       reinterpret_cast<double*>(task_data->inputs[0]) + dimension_);
+  upper_bounds_.assign(reinterpret_cast<double*>(task_data->inputs[1]),
+                       reinterpret_cast<double*>(task_data->inputs[1]) + dimension_);
+
+  const int* params = reinterpret_cast<int*>(task_data->inputs[2]);
+  segments_per_dim_ = params[0];
+  function_id_ = params[1];
+
+  result_ = 0.0;
+  return true;
+}
+
+bool SimpsonNDOpenMP::ValidationImpl() {
+  if (task_data->inputs_count.size() < 3) {
+    return false;
+  }
+  if (task_data->outputs_count.empty()) {
+    return false;
+  }
+  if (task_data->outputs_count[0] != 1) {
+    return false;
+  }
+
+  const int dim = static_cast<int>(task_data->inputs_count[0]);
+  if (dim <= 0) {
+    return false;
+  }
+  if (static_cast<int>(task_data->inputs_count[1]) != dim) {
+    return false;
+  }
+  if (task_data->inputs_count[2] != 2) {
+    return false;
+  }
+
+  const double* lb = reinterpret_cast<double*>(task_data->inputs[0]);
+  const double* ub = reinterpret_cast<double*>(task_data->inputs[1]);
+  for (int i = 0; i < dim; ++i) {
+    if (!(ub[i] > lb[i])) {
+      return false;
+    }
+  }
+
+  const int* params = reinterpret_cast<int*>(task_data->inputs[2]);
+  const int segments = params[0];
+  return segments > 0 && (segments % 2) == 0;
+}
+
+bool SimpsonNDOpenMP::RunImpl() {
+  std::vector<double> h(dimension_);
+  for (int d = 0; d < dimension_; ++d) {
+    h[d] = (upper_bounds_[d] - lower_bounds_[d]) / static_cast<double>(segments_per_dim_);
+  }
+
+  const long long points_per_dim = static_cast<long long>(segments_per_dim_) + 1;
+  const auto total_points = static_cast<long long>(std::pow(points_per_dim, dimension_));
+
+  double sum = 0.0;
+
+#pragma omp parallel
+  {
+    std::vector<int> idx(dimension_, 0);
+    std::vector<double> x(dimension_, 0.0);
+    double local_sum = 0.0;
+
+#pragma omp for nowait schedule(static)
+    for (long long linear = 0; linear < total_points; ++linear) {
+      long long tmp = linear;
+      double weight = 1.0;
+      for (int d = 0; d < dimension_; ++d) {
+        idx[d] = static_cast<int>(tmp % points_per_dim);
+        tmp /= points_per_dim;
+        x[d] = lower_bounds_[d] + h[d] * static_cast<double>(idx[d]);
+        if (idx[d] == 0 || idx[d] == segments_per_dim_) {
+          weight *= 1.0;
+        } else if ((idx[d] % 2) == 1) {
+          weight *= 4.0;
+        } else {
+          weight *= 2.0;
+        }
+      }
+      local_sum += weight * EvaluateById(function_id_, x);
+    }
+
+#pragma omp atomic
+    sum += local_sum;
+  }
+
+  double scale = 1.0;
+  for (int d = 0; d < dimension_; ++d) {
+    scale *= h[d] / 3.0;
+  }
+  result_ = sum * scale;
+  return true;
+}
+
+bool SimpsonNDOpenMP::PostProcessingImpl() {
+  reinterpret_cast<double*>(task_data->outputs[0])[0] = result_;
+  return true;
+}
+
+double SimpsonNDOpenMP::EvaluateFunction(const std::vector<double>& point) const {
+  return EvaluateById(function_id_, point);
+}
+
+}  // namespace kalinin_d_simpson_method_omp


### PR DESCRIPTION
В методе Симпсона с использованием OpenMP вычисления интеграла могут быть распараллелены: интервал разбивается на части, каждая из которых обрабатывается отдельным потоком. 