### PR TITLE
[ПЕРЕСДАЧА] Кавторев Дмитрий Константинович 3822Б1ПР2 OMP

### DIFF
--- a/tasks/omp/kavtorev_d_batcher_sort/func_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/func_tests/main.cpp
@@ -1,0 +1,147 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "omp/kavtorev_d_batcher_sort/include/ops_omp.hpp"
+
+using kavtorev_d_batcher_sort_omp::RadixBatcherSortOpenMP;
+
+namespace {
+std::vector<double> RunTask(const std::vector<double>& input) {
+  std::vector<double> out(input.size());
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(input.data())));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  RadixBatcherSortOpenMP task(task_data_omp);
+  EXPECT_TRUE(task.Validation());
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  return out;
+}
+}  // namespace
+
+TEST(kavtorev_d_batcher_sort_omp, handles_empty) {
+  std::vector<double> in;
+  auto out = RunTask(in);
+  EXPECT_TRUE(out.empty());
+}
+
+TEST(kavtorev_d_batcher_sort_omp, handles_single) {
+  std::vector<double> in{42.0};
+  auto out = RunTask(in);
+  EXPECT_EQ(out.size(), static_cast<size_t>(1));
+  EXPECT_DOUBLE_EQ(out[0], 42.0);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_already_sorted) {
+  std::vector<double> in{-5.0, -1.0, 0.0, 0.5, 2.0};
+  auto out = RunTask(in);
+  EXPECT_EQ(out, in);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_reverse_sorted) {
+  std::vector<double> in{9.0, 4.0, 1.0, -2.0, -7.0};
+  auto out = RunTask(in);
+  std::sort(in.begin(), in.end());  // NOLINT(modernize-use-ranges)
+  EXPECT_EQ(out, in);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_with_duplicates) {
+  std::vector<double> in{3.0, 2.0, 3.0, -1.0, 2.0, 3.0};
+  auto out = RunTask(in);
+  std::sort(in.begin(), in.end());  // NOLINT(modernize-use-ranges)
+  EXPECT_EQ(out, in);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_negatives_and_positives) {
+  std::vector<double> in{-0.1, -100.0, 50.5, 0.0, 3.14};
+  auto out = RunTask(in);
+  std::sort(in.begin(), in.end());  // NOLINT(modernize-use-ranges)
+  EXPECT_EQ(out, in);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_with_infinities) {
+  std::vector<double> in{-std::numeric_limits<double>::infinity(), -1.0, 0.0, 1.0,
+                         std::numeric_limits<double>::infinity()};
+  auto out = RunTask(in);
+  EXPECT_EQ(out, in);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_with_nan_moved_last) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> in{3.0, nan, -1.0, 2.0};
+  auto out = RunTask(in);
+  std::vector<double> ref{-1.0, 2.0, 3.0, nan};
+  for (size_t i = 0; i + 1 < out.size() - 0; ++i) {
+    if (!std::isnan(out[i + 1])) {
+      EXPECT_LE(out[i], out[i + 1]);
+    }
+  }
+  EXPECT_TRUE(std::isnan(out.back()));
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_random_small) {
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<double> d(-1000.0, 1000.0);
+  std::vector<double> in(101);
+  for (auto& v : in) {
+    v = d(gen);
+  }
+  auto out = RunTask(in);
+  std::sort(in.begin(), in.end());  // NOLINT(modernize-use-ranges)
+  ASSERT_EQ(out.size(), in.size());
+  for (size_t i = 0; i < in.size(); ++i) {
+    EXPECT_DOUBLE_EQ(out[i], in[i]);
+  }
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_power_of_two) {
+  std::vector<double> in{8, 7, 6, 5, 4, 3, 2, 1};
+  auto out = RunTask(in);
+  std::sort(in.begin(), in.end());  // NOLINT(modernize-use-ranges)
+  EXPECT_EQ(out, in);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, sorts_large_random) {
+  std::mt19937 gen(7);
+  std::normal_distribution<double> d(0.0, 100.0);
+  std::vector<double> in(500);
+  for (auto& v : in) {
+    v = d(gen);
+  }
+  auto out = RunTask(in);
+  auto ref = in;
+  std::sort(ref.begin(), ref.end());  // NOLINT(modernize-use-ranges)
+  EXPECT_EQ(out, ref);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, file_driven_small) {
+  std::string line;
+  std::ifstream test_file(ppc::util::GetAbsolutePath("seq/example/data/test.txt"));
+  if (test_file.is_open()) {
+    getline(test_file, line);
+  }
+  test_file.close();
+  const size_t count = std::stoi(line);
+  std::vector<double> in(count);
+  for (size_t i = 0; i < count; ++i) {
+    in[i] = static_cast<double>(count - i);
+  }
+  auto out = RunTask(in);
+  std::sort(in.begin(), in.end());  // NOLINT(modernize-use-ranges)
+  EXPECT_EQ(out, in);
+}

--- a/tasks/omp/kavtorev_d_batcher_sort/include/ops_omp.hpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/include/ops_omp.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kavtorev_d_batcher_sort_omp {
+
+class RadixBatcherSortOpenMP : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_;
+  std::vector<double> output_;
+
+  static inline uint64_t ToOrderedUint64(double value);
+  static inline double FromOrderedUint64(uint64_t key);
+  static void LsdRadixSortUint64(std::vector<uint64_t>& data);
+
+  static void OddEvenMerge(std::vector<double>& a, int left, int size, int stride);
+  static void OddEvenMergeSort(std::vector<double>& a, int left, int size);
+};
+
+}  // namespace kavtorev_d_batcher_sort_omp

--- a/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -9,12 +10,37 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "omp/kavtorev_d_batcher_sort/include/ops_omp.hpp"
+#include "tbb/kavtorev_d_batcher_sort/include/ops_tbb.hpp"
 
-using kavtorev_d_batcher_sort_omp::RadixBatcherSortOpenMP;
+using kavtorev_d_batcher_sort_tbb::RadixBatcherSortTBB;
 
-TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
-  constexpr size_t kCount = 500000;
+bool IsSorted(const std::vector<double>& arr) {
+  for (size_t i = 1; i < arr.size(); ++i) {
+    if (arr[i] < arr[i - 1]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SameElements(const std::vector<double>& a, const std::vector<double>& b) {
+  if (a.size() != b.size()) return false;
+
+  std::vector<double> sorted_a = a;
+  std::vector<double> sorted_b = b;
+  std::sort(sorted_a.begin(), sorted_a.end());
+  std::sort(sorted_b.begin(), sorted_b.end());
+
+  for (size_t i = 0; i < sorted_a.size(); ++i) {
+    if (std::abs(sorted_a[i] - sorted_b[i]) > 1e-12) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST(kavtorev_d_batcher_sort_tbb, perf_pipeline_run) {
+  constexpr size_t kCount = 2000000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
   std::mt19937 gen(123);
@@ -22,12 +48,15 @@ TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
   for (auto& v : in) {
     v = d(gen);
   }
-  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
-  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  task_data_omp->inputs_count.emplace_back(in.size());
-  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_omp->outputs_count.emplace_back(out.size());
-  auto task = std::make_shared<RadixBatcherSortOpenMP>(task_data_omp);
+
+  std::vector<double> original = in;
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_tbb->inputs_count.emplace_back(in.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+  auto task = std::make_shared<RadixBatcherSortTBB>(task_data_tbb);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 5;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -40,10 +69,25 @@ TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  EXPECT_TRUE(IsSorted(out));
+  EXPECT_TRUE(SameElements(original, out));
+
+  std::vector<double> std_sorted = original;
+  std::sort(std_sorted.begin(), std_sorted.end());
+
+  bool matches_std_sort = true;
+  for (size_t i = 0; i < out.size(); ++i) {
+    if (std::abs(out[i] - std_sorted[i]) > 1e-12) {
+      matches_std_sort = false;
+      break;
+    }
+  }
+  EXPECT_TRUE(matches_std_sort);
 }
 
-TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
-  constexpr size_t kCount = 500000;
+TEST(kavtorev_d_batcher_sort_tbb, perf_task_run) {
+  constexpr size_t kCount = 2000000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
   std::mt19937 gen(321);
@@ -51,12 +95,15 @@ TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
   for (auto& v : in) {
     v = d(gen);
   }
-  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
-  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  task_data_omp->inputs_count.emplace_back(in.size());
-  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_omp->outputs_count.emplace_back(out.size());
-  auto task = std::make_shared<RadixBatcherSortOpenMP>(task_data_omp);
+
+  std::vector<double> original = in;
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_tbb->inputs_count.emplace_back(in.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+  auto task = std::make_shared<RadixBatcherSortTBB>(task_data_tbb);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 5;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -69,4 +116,19 @@ TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  EXPECT_TRUE(IsSorted(out)) << "Array is not sorted correctly";
+  EXPECT_TRUE(SameElements(original, out)) << "Sorted array doesn't contain the same elements as input";
+
+  std::vector<double> std_sorted = original;
+  std::sort(std_sorted.begin(), std_sorted.end());
+
+  bool matches_std_sort = true;
+  for (size_t i = 0; i < out.size(); ++i) {
+    if (std::abs(out[i] - std_sorted[i]) > 1e-12) {
+      matches_std_sort = false;
+      break;
+    }
+  }
+  EXPECT_TRUE(matches_std_sort) << "Result doesn't match std::sort";
 }

--- a/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
@@ -10,9 +10,9 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "tbb/kavtorev_d_batcher_sort/include/ops_tbb.hpp"
+#include "omp/kavtorev_d_batcher_sort/include/ops_omp.hpp"
 
-using kavtorev_d_batcher_sort_tbb::RadixBatcherSortTBB;
+using kavtorev_d_batcher_sort_omp::RadixBatcherSortOpenMP;
 
 bool IsSorted(const std::vector<double>& arr) {
   for (size_t i = 1; i < arr.size(); ++i) {
@@ -39,7 +39,7 @@ bool SameElements(const std::vector<double>& a, const std::vector<double>& b) {
   return true;
 }
 
-TEST(kavtorev_d_batcher_sort_tbb, perf_pipeline_run) {
+TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
   constexpr size_t kCount = 2000000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
@@ -51,12 +51,12 @@ TEST(kavtorev_d_batcher_sort_tbb, perf_pipeline_run) {
 
   std::vector<double> original = in;
 
-  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
-  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  task_data_tbb->inputs_count.emplace_back(in.size());
-  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_tbb->outputs_count.emplace_back(out.size());
-  auto task = std::make_shared<RadixBatcherSortTBB>(task_data_tbb);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  auto task = std::make_shared<RadixBatcherSortOpenMP>(task_data_omp);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 5;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -86,7 +86,7 @@ TEST(kavtorev_d_batcher_sort_tbb, perf_pipeline_run) {
   EXPECT_TRUE(matches_std_sort);
 }
 
-TEST(kavtorev_d_batcher_sort_tbb, perf_task_run) {
+TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
   constexpr size_t kCount = 2000000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
@@ -98,12 +98,12 @@ TEST(kavtorev_d_batcher_sort_tbb, perf_task_run) {
 
   std::vector<double> original = in;
 
-  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
-  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  task_data_tbb->inputs_count.emplace_back(in.size());
-  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_tbb->outputs_count.emplace_back(out.size());
-  auto task = std::make_shared<RadixBatcherSortTBB>(task_data_tbb);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  auto task = std::make_shared<RadixBatcherSortOpenMP>(task_data_omp);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 5;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -117,8 +117,8 @@ TEST(kavtorev_d_batcher_sort_tbb, perf_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  EXPECT_TRUE(IsSorted(out)) << "Array is not sorted correctly";
-  EXPECT_TRUE(SameElements(original, out)) << "Sorted array doesn't contain the same elements as input";
+  EXPECT_TRUE(IsSorted(out));
+  EXPECT_TRUE(SameElements(original, out));
 
   std::vector<double> std_sorted = original;
   std::sort(std_sorted.begin(), std_sorted.end());
@@ -130,5 +130,5 @@ TEST(kavtorev_d_batcher_sort_tbb, perf_task_run) {
       break;
     }
   }
-  EXPECT_TRUE(matches_std_sort) << "Result doesn't match std::sort";
+  EXPECT_TRUE(matches_std_sort);
 }

--- a/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/kavtorev_d_batcher_sort/include/ops_omp.hpp"
+
+using kavtorev_d_batcher_sort_omp::RadixBatcherSortOpenMP;
+
+TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
+  constexpr size_t kCount = 2000000;
+  std::vector<double> in(kCount);
+  std::vector<double> out(kCount);
+  std::mt19937 gen(123);
+  std::uniform_real_distribution<double> d(-1e6, 1e6);
+  for (auto& v : in) {
+    v = d(gen);
+  }
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  auto task = std::make_shared<RadixBatcherSortOpenMP>(task_data_omp);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
+  constexpr size_t kCount = 2000000;
+  std::vector<double> in(kCount);
+  std::vector<double> out(kCount);
+  std::mt19937 gen(321);
+  std::uniform_real_distribution<double> d(-1e6, 1e6);
+  for (auto& v : in) {
+    v = d(gen);
+  }
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  auto task = std::make_shared<RadixBatcherSortOpenMP>(task_data_omp);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
@@ -14,7 +14,7 @@
 using kavtorev_d_batcher_sort_omp::RadixBatcherSortOpenMP;
 
 TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
-  constexpr size_t kCount = 2000000;
+  constexpr size_t kCount = 500000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
   std::mt19937 gen(123);
@@ -43,7 +43,7 @@ TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
 }
 
 TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
-  constexpr size_t kCount = 2000000;
+  constexpr size_t kCount = 500000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
   std::mt19937 gen(321);

--- a/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -14,6 +15,8 @@
 
 using kavtorev_d_batcher_sort_omp::RadixBatcherSortOpenMP;
 
+namespace {
+
 bool IsSorted(const std::vector<double>& arr) {
   for (size_t i = 1; i < arr.size(); ++i) {
     if (arr[i] < arr[i - 1]) {
@@ -24,12 +27,14 @@ bool IsSorted(const std::vector<double>& arr) {
 }
 
 bool SameElements(const std::vector<double>& a, const std::vector<double>& b) {
-  if (a.size() != b.size()) return false;
+  if (a.size() != b.size()) {
+    return false;
+  }
 
   std::vector<double> sorted_a = a;
   std::vector<double> sorted_b = b;
-  std::sort(sorted_a.begin(), sorted_a.end());
-  std::sort(sorted_b.begin(), sorted_b.end());
+  std::ranges::sort(sorted_a);
+  std::ranges::sort(sorted_b);
 
   for (size_t i = 0; i < sorted_a.size(); ++i) {
     if (std::abs(sorted_a[i] - sorted_b[i]) > 1e-12) {
@@ -38,6 +43,8 @@ bool SameElements(const std::vector<double>& a, const std::vector<double>& b) {
   }
   return true;
 }
+
+}  // namespace
 
 TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
   constexpr size_t kCount = 2000000;
@@ -74,7 +81,7 @@ TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
   EXPECT_TRUE(SameElements(original, out));
 
   std::vector<double> std_sorted = original;
-  std::sort(std_sorted.begin(), std_sorted.end());
+  std::ranges::sort(std_sorted);
 
   bool matches_std_sort = true;
   for (size_t i = 0; i < out.size(); ++i) {
@@ -121,7 +128,7 @@ TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
   EXPECT_TRUE(SameElements(original, out));
 
   std::vector<double> std_sorted = original;
-  std::sort(std_sorted.begin(), std_sorted.end());
+  std::ranges::sort(std_sorted);
 
   bool matches_std_sort = true;
   for (size_t i = 0; i < out.size(); ++i) {

--- a/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/perf_tests/main.cpp
@@ -47,7 +47,7 @@ bool SameElements(const std::vector<double>& a, const std::vector<double>& b) {
 }  // namespace
 
 TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
-  constexpr size_t kCount = 2000000;
+  constexpr size_t kCount = 500000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
   std::mt19937 gen(123);
@@ -94,7 +94,7 @@ TEST(kavtorev_d_batcher_sort_omp, perf_pipeline_run) {
 }
 
 TEST(kavtorev_d_batcher_sort_omp, perf_task_run) {
-  constexpr size_t kCount = 2000000;
+  constexpr size_t kCount = 500000;
   std::vector<double> in(kCount);
   std::vector<double> out(kCount);
   std::mt19937 gen(321);

--- a/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
@@ -101,13 +101,9 @@ void RadixBatcherSortOpenMP::OddEvenMergeSort(std::vector<double>& a, int left, 
 #pragma omp parallel sections
     {
 #pragma omp section
-      {
-        OddEvenMergeSort(a, left, mid);
-      }
+      { OddEvenMergeSort(a, left, mid); }
 #pragma omp section
-      {
-        OddEvenMergeSort(a, left + mid, mid);
-      }
+      { OddEvenMergeSort(a, left + mid, mid); }
     }
 
     OddEvenMerge(a, left, size, 1);

--- a/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
@@ -85,7 +85,6 @@ void RadixBatcherSortOpenMP::OddEvenMerge(std::vector<double>& a, int left, int 
     OddEvenMerge(a, left, size, m);
     OddEvenMerge(a, left + stride, size, m);
 
-#pragma omp parallel for schedule(static)
     for (int i = left + stride; i + stride < left + size; i += m) {
       CompSwap(a[i], a[i + stride]);
     }

--- a/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
@@ -1,0 +1,174 @@
+#include "omp/kavtorev_d_batcher_sort/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace kavtorev_d_batcher_sort_omp {
+
+static inline void CompSwap(double& a, double& b) {
+  if (a > b) {
+    std::swap(a, b);
+  }
+}
+
+inline uint64_t RadixBatcherSortOpenMP::ToOrderedUint64(double value) {
+  uint64_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(double));
+  if ((bits >> 63) != 0U) {
+    bits = ~bits;
+  } else {
+    bits ^= (uint64_t{1} << 63);
+  }
+  return bits;
+}
+
+inline double RadixBatcherSortOpenMP::FromOrderedUint64(uint64_t key) {
+  if ((key >> 63) != 0U) {
+    key ^= (uint64_t{1} << 63);
+  } else {
+    key = ~key;
+  }
+  double value = NAN;
+  std::memcpy(&value, &key, sizeof(double));
+  return value;
+}
+
+void RadixBatcherSortOpenMP::LsdRadixSortUint64(std::vector<uint64_t>& data) {
+  const size_t n = data.size();
+  if (n <= 1) {
+    return;
+  }
+  std::vector<uint64_t> buffer(n);
+  constexpr int kBytes = 8;
+  constexpr int kRadix = 256;
+
+  for (int byte = 0; byte < kBytes; ++byte) {
+    size_t count[kRadix] = {0};
+    const int shift = byte * 8;
+
+#pragma omp parallel for schedule(static)
+    for (size_t i = 0; i < n; ++i) {
+      auto r = static_cast<uint8_t>((data[i] >> shift) & 0xFFU);
+#pragma omp atomic
+      count[r]++;
+    }
+
+    size_t sum = 0;
+    for (int r = 0; r < kRadix; ++r) {
+      size_t c = count[r];
+      count[r] = sum;
+      sum += c;
+    }
+
+#pragma omp parallel for schedule(static)
+    for (size_t i = 0; i < n; ++i) {
+      auto r = static_cast<uint8_t>((data[i] >> shift) & 0xFFU);
+      size_t pos;
+#pragma omp atomic capture
+      pos = count[r]++;
+      buffer[pos] = data[i];
+    }
+    data.swap(buffer);
+  }
+}
+
+void RadixBatcherSortOpenMP::OddEvenMerge(std::vector<double>& a, int left, int size, int stride) {
+  int m = stride * 2;
+  if (m < size) {
+    OddEvenMerge(a, left, size, m);
+    OddEvenMerge(a, left + stride, size, m);
+
+#pragma omp parallel for schedule(static)
+    for (int i = left + stride; i + stride < left + size; i += m) {
+      CompSwap(a[i], a[i + stride]);
+    }
+  } else {
+    CompSwap(a[left], a[left + stride]);
+  }
+}
+
+void RadixBatcherSortOpenMP::OddEvenMergeSort(std::vector<double>& a, int left, int size) {
+  if (size > 1) {
+    int mid = size / 2;
+
+#pragma omp parallel sections
+    {
+#pragma omp section
+      {
+        OddEvenMergeSort(a, left, mid);
+      }
+#pragma omp section
+      {
+        OddEvenMergeSort(a, left + mid, mid);
+      }
+    }
+
+    OddEvenMerge(a, left, size, 1);
+  }
+}
+
+bool RadixBatcherSortOpenMP::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  input_ = std::vector<double>(in_ptr, in_ptr + input_size);
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<double>(output_size, 0.0);
+  return true;
+}
+
+bool RadixBatcherSortOpenMP::ValidationImpl() { return task_data->inputs_count[0] == task_data->outputs_count[0]; }
+
+bool RadixBatcherSortOpenMP::RunImpl() {
+  if (input_.empty()) {
+    return true;
+  }
+
+  std::vector<uint64_t> keys(input_.size());
+
+#pragma omp parallel for schedule(static)
+  for (size_t i = 0; i < input_.size(); ++i) {
+    keys[i] = ToOrderedUint64(input_[i]);
+  }
+
+  LsdRadixSortUint64(keys);
+
+  std::vector<double> sorted(input_.size());
+
+#pragma omp parallel for schedule(static)
+  for (size_t i = 0; i < keys.size(); ++i) {
+    sorted[i] = FromOrderedUint64(keys[i]);
+  }
+
+  size_t n = sorted.size();
+  size_t pow2 = 1;
+  while (pow2 < n) {
+    pow2 <<= 1;
+  }
+  std::vector<double> padded = sorted;
+  if (pow2 != n) {
+    padded.resize(pow2, std::numeric_limits<double>::infinity());
+  }
+
+  OddEvenMergeSort(padded, 0, static_cast<int>(padded.size()));
+
+  output_.resize(n);
+  std::copy(padded.begin(), padded.begin() + static_cast<ptrdiff_t>(n), output_.begin());
+  return true;
+}
+
+bool RadixBatcherSortOpenMP::PostProcessingImpl() {
+#pragma omp parallel for schedule(static)
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<double*>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}
+
+}  // namespace kavtorev_d_batcher_sort_omp

--- a/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
@@ -13,7 +13,7 @@
 namespace kavtorev_d_batcher_sort_omp {
 
 namespace {
-static inline void CompSwap(double& a, double& b) {
+inline void CompSwap(double& a, double& b) {
   if (a > b) {
     std::swap(a, b);
   }

--- a/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
@@ -12,11 +12,13 @@
 
 namespace kavtorev_d_batcher_sort_omp {
 
+namespace {
 static inline void CompSwap(double& a, double& b) {
   if (a > b) {
     std::swap(a, b);
   }
 }
+}  // namespace
 
 inline uint64_t RadixBatcherSortOpenMP::ToOrderedUint64(double value) {
   uint64_t bits = 0;
@@ -70,11 +72,9 @@ void RadixBatcherSortOpenMP::LsdRadixSortUint64(std::vector<uint64_t>& data) {
 #pragma omp parallel for schedule(static)
     for (int i = 0; i < static_cast<int>(n); ++i) {
       auto r = static_cast<uint8_t>((data[i] >> shift) & 0xFFU);
-      size_t pos;
+      size_t pos = 0;
 #pragma omp critical
-      {
-        pos = count[r]++;
-      }
+      { pos = count[r]++; }
       buffer[pos] = data[i];
     }
     data.swap(buffer);
@@ -102,9 +102,13 @@ void RadixBatcherSortOpenMP::OddEvenMergeSort(std::vector<double>& a, int left, 
 #pragma omp parallel sections
     {
 #pragma omp section
-      { OddEvenMergeSort(a, left, mid); }
+      {
+        OddEvenMergeSort(a, left, mid);
+      }
 #pragma omp section
-      { OddEvenMergeSort(a, left + mid, mid); }
+      {
+        OddEvenMergeSort(a, left + mid, mid);
+      }
     }
 
     OddEvenMerge(a, left, size, 1);

--- a/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
+++ b/tasks/omp/kavtorev_d_batcher_sort/src/ops_omp.cpp
@@ -102,13 +102,9 @@ void RadixBatcherSortOpenMP::OddEvenMergeSort(std::vector<double>& a, int left, 
 #pragma omp parallel sections
     {
 #pragma omp section
-      {
-        OddEvenMergeSort(a, left, mid);
-      }
+      { OddEvenMergeSort(a, left, mid); }
 #pragma omp section
-      {
-        OddEvenMergeSort(a, left + mid, mid);
-      }
+      { OddEvenMergeSort(a, left + mid, mid); }
     }
 
     OddEvenMerge(a, left, size, 1);


### PR DESCRIPTION
Реализован алгоритм поразрядной сортировки для вещественных чисел (тип double) с использованием четно-нечетного слияния Бэтчера при помощи технологии OpenMP. Алгоритм работает в три этапа: преобразование double в сортируемые uint64_t ключи с сохранением численного порядка, поразрядная сортировка по байтам (LSD), и применение сети Бэтчера для четно-нечетного слияния.