### PR TITLE
[ПЕРЕСДАЧА] Махов Михаил Александрович 3822Б1ПР2 OMP

### DIFF
--- a/tasks/omp/makhov_m_jarvis_algorithm/func_tests/main.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/func_tests/main.cpp
@@ -63,7 +63,7 @@ TEST(makhov_m_jarvis_algorithm_omp, test_three_points) {
   // Restore result from task_data
   std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
-                                                                              task_data_seq->outputs_count[0]);
+                                                                       task_data_seq->outputs_count[0]);
   ASSERT_EQ(reference.size(), restored_points.size());
 
   // Cleanup
@@ -107,7 +107,7 @@ TEST(makhov_m_jarvis_algorithm_omp, test_five_points) {
   // Restore result from task_data
   std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
-                                                                              task_data_seq->outputs_count[0]);
+                                                                       task_data_seq->outputs_count[0]);
 
   ASSERT_EQ(reference.size(), restored_points.size());
 
@@ -150,7 +150,7 @@ TEST(makhov_m_jarvis_algorithm_omp, test_ten_points) {
   // Restore result from task_data
   std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
-                                                                              task_data_seq->outputs_count[0]);
+                                                                       task_data_seq->outputs_count[0]);
 
   // Should have a convex hull with at least 3 points
   size_t expected_size = 3;
@@ -190,7 +190,7 @@ TEST(makhov_m_jarvis_algorithm_omp, test_five_points_negative_coords) {
   // Restore result from task_data
   std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
-                                                                              task_data_seq->outputs_count[0]);
+                                                                       task_data_seq->outputs_count[0]);
 
   // Should have a convex hull with at least 3 points
   size_t expected_size = 3;
@@ -232,7 +232,7 @@ TEST(makhov_m_jarvis_algorithm_omp, test_hundred_rand_points) {
   // Restore result from task_data
   std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
-                                                                              task_data_seq->outputs_count[0]);
+                                                                       task_data_seq->outputs_count[0]);
 
   // Should have a convex hull with at least 3 points
   size_t expected_size = 3;
@@ -274,7 +274,7 @@ TEST(makhov_m_jarvis_algorithm_omp, test_thousand_rand_points) {
   // Restore result from task_data
   std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
-                                                                              task_data_seq->outputs_count[0]);
+                                                                       task_data_seq->outputs_count[0]);
 
   // Should have a convex hull with at least 3 points
   size_t expected_size = 3;

--- a/tasks/omp/makhov_m_jarvis_algorithm/func_tests/main.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/func_tests/main.cpp
@@ -1,0 +1,286 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/makhov_m_jarvis_algorithm/include/ops_omp.hpp"
+
+TEST(makhov_m_jarvis_algorithm_omp, test_two_points) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(2);
+  in[0].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  in[1].Set(makhov_m_jarvis_algorithm_omp::XCoord(2.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), false);
+
+  // Cleanup
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_three_points) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(3);
+  in[0].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  in[1].Set(makhov_m_jarvis_algorithm_omp::XCoord(2.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  in[2].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(2.0));
+
+  // Create reference
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> reference = in;
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), true);
+  ASSERT_EQ(task_sequential.PreProcessing(), true);
+  ASSERT_EQ(task_sequential.Run(), true);
+  ASSERT_EQ(task_sequential.PostProcessing(), true);
+
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                              task_data_seq->outputs_count[0]);
+  ASSERT_EQ(reference.size(), restored_points.size());
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_five_points) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(5);
+  in[0].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  in[1].Set(makhov_m_jarvis_algorithm_omp::XCoord(4.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  in[2].Set(makhov_m_jarvis_algorithm_omp::XCoord(4.0), makhov_m_jarvis_algorithm_omp::YCoord(4.0));
+  in[3].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(4.0));
+  in[4].Set(makhov_m_jarvis_algorithm_omp::XCoord(2.0), makhov_m_jarvis_algorithm_omp::YCoord(2.0));
+
+  // Create reference (convex hull should be the 4 corner points)
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> reference(4);
+  reference[0].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  reference[1].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(4.0));
+  reference[2].Set(makhov_m_jarvis_algorithm_omp::XCoord(4.0), makhov_m_jarvis_algorithm_omp::YCoord(4.0));
+  reference[3].Set(makhov_m_jarvis_algorithm_omp::XCoord(4.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), true);
+  ASSERT_EQ(task_sequential.PreProcessing(), true);
+  ASSERT_EQ(task_sequential.Run(), true);
+  ASSERT_EQ(task_sequential.PostProcessing(), true);
+
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                              task_data_seq->outputs_count[0]);
+
+  ASSERT_EQ(reference.size(), restored_points.size());
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_ten_points) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(10);
+  in[0].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(0.0));
+  in[1].Set(makhov_m_jarvis_algorithm_omp::XCoord(3.0), makhov_m_jarvis_algorithm_omp::YCoord(1.0));
+  in[2].Set(makhov_m_jarvis_algorithm_omp::XCoord(7.0), makhov_m_jarvis_algorithm_omp::YCoord(1.0));
+  in[3].Set(makhov_m_jarvis_algorithm_omp::XCoord(8.0), makhov_m_jarvis_algorithm_omp::YCoord(4.0));
+  in[4].Set(makhov_m_jarvis_algorithm_omp::XCoord(6.0), makhov_m_jarvis_algorithm_omp::YCoord(6.0));
+  in[5].Set(makhov_m_jarvis_algorithm_omp::XCoord(3.0), makhov_m_jarvis_algorithm_omp::YCoord(8.0));
+  in[6].Set(makhov_m_jarvis_algorithm_omp::XCoord(5.0), makhov_m_jarvis_algorithm_omp::YCoord(3.0));
+  in[7].Set(makhov_m_jarvis_algorithm_omp::XCoord(3.0), makhov_m_jarvis_algorithm_omp::YCoord(5.0));
+  in[8].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(5.0));
+  in[9].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(2.0));
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), true);
+  ASSERT_EQ(task_sequential.PreProcessing(), true);
+  ASSERT_EQ(task_sequential.Run(), true);
+  ASSERT_EQ(task_sequential.PostProcessing(), true);
+
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                              task_data_seq->outputs_count[0]);
+
+  // Should have a convex hull with at least 3 points
+  size_t expected_size = 3;
+  ASSERT_GE(restored_points.size(), expected_size);
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_five_points_negative_coords) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(5);
+  in[0].Set(makhov_m_jarvis_algorithm_omp::XCoord(-2.0), makhov_m_jarvis_algorithm_omp::YCoord(-2.0));
+  in[1].Set(makhov_m_jarvis_algorithm_omp::XCoord(2.0), makhov_m_jarvis_algorithm_omp::YCoord(1.0));
+  in[2].Set(makhov_m_jarvis_algorithm_omp::XCoord(-3.0), makhov_m_jarvis_algorithm_omp::YCoord(4.0));
+  in[3].Set(makhov_m_jarvis_algorithm_omp::XCoord(-1.0), makhov_m_jarvis_algorithm_omp::YCoord(2.0));
+  in[4].Set(makhov_m_jarvis_algorithm_omp::XCoord(0.0), makhov_m_jarvis_algorithm_omp::YCoord(1.0));
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), true);
+  ASSERT_EQ(task_sequential.PreProcessing(), true);
+  ASSERT_EQ(task_sequential.Run(), true);
+  ASSERT_EQ(task_sequential.PostProcessing(), true);
+
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                              task_data_seq->outputs_count[0]);
+
+  // Should have a convex hull with at least 3 points
+  size_t expected_size = 3;
+  ASSERT_GE(restored_points.size(), expected_size);
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_hundred_rand_points) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(100);
+
+  for (size_t i = 0; i < in.size(); i++) {
+    makhov_m_jarvis_algorithm_omp::Point point = makhov_m_jarvis_algorithm_omp::TaskOmp::GetRandomPoint(
+        makhov_m_jarvis_algorithm_omp::XCoord(-10.0), makhov_m_jarvis_algorithm_omp::XCoord(10.0),
+        makhov_m_jarvis_algorithm_omp::YCoord(-10.0), makhov_m_jarvis_algorithm_omp::YCoord(10.0));
+    in[i] = point;
+  }
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), true);
+  ASSERT_EQ(task_sequential.PreProcessing(), true);
+  ASSERT_EQ(task_sequential.Run(), true);
+  ASSERT_EQ(task_sequential.PostProcessing(), true);
+
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                              task_data_seq->outputs_count[0]);
+
+  // Should have a convex hull with at least 3 points
+  size_t expected_size = 3;
+  ASSERT_GE(restored_points.size(), expected_size);
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_thousand_rand_points) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(1000);
+
+  for (size_t i = 0; i < in.size(); i++) {
+    makhov_m_jarvis_algorithm_omp::Point point = makhov_m_jarvis_algorithm_omp::TaskOmp::GetRandomPoint(
+        makhov_m_jarvis_algorithm_omp::XCoord(-10.0), makhov_m_jarvis_algorithm_omp::XCoord(10.0),
+        makhov_m_jarvis_algorithm_omp::YCoord(-10.0), makhov_m_jarvis_algorithm_omp::YCoord(10.0));
+    in[i] = point;
+  }
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  makhov_m_jarvis_algorithm_omp::TaskOmp task_sequential(task_data_seq);
+  ASSERT_EQ(task_sequential.Validation(), true);
+  ASSERT_EQ(task_sequential.PreProcessing(), true);
+  ASSERT_EQ(task_sequential.Run(), true);
+  ASSERT_EQ(task_sequential.PostProcessing(), true);
+
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                              task_data_seq->outputs_count[0]);
+
+  // Should have a convex hull with at least 3 points
+  size_t expected_size = 3;
+  ASSERT_GE(restored_points.size(), expected_size);
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
+  delete[] buffer;
+}

--- a/tasks/omp/makhov_m_jarvis_algorithm/include/ops_omp.hpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/include/ops_omp.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace makhov_m_jarvis_algorithm_omp {
+
+struct XCoord {
+  double value;
+  explicit XCoord(double v) : value(v) {}
+};
+
+struct YCoord {
+  double value;
+  explicit YCoord(double v) : value(v) {}
+};
+
+struct Point {
+ public:
+  double x, y;
+
+  Point() : x(0), y(0) {}
+  Point(XCoord x, YCoord y) : x(x.value), y(y.value) {}
+
+  [[nodiscard]] double GetX() const { return x; }
+  [[nodiscard]] double GetY() const { return y; }
+  void SetX(double x_coord) { x = x_coord; }
+  void SetY(double y_coord) { y = y_coord; }
+  void Set(XCoord x_coord, YCoord y_coord) {
+    x = x_coord.value;
+    y = y_coord.value;
+  }
+
+  [[nodiscard]] double DistanceTo(const Point& other) const {
+    double dx = x - other.x;
+    double dy = y - other.y;
+    return std::sqrt((dx * dx) + (dy * dy));
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const Point& point) {
+    std::ios old_state(nullptr);
+    old_state.copyfmt(os);
+    os << "(" << std::fixed << std::setprecision(2) << point.x << ", " << point.y << ")";
+    os.copyfmt(old_state);
+    return os;
+  }
+
+  bool operator==(const Point& other) const { return x == other.x && y == other.y; }
+  bool operator!=(const Point& other) const { return !(*this == other); }
+};
+
+class TaskOmp : public ppc::core::Task {
+ public:
+  explicit TaskOmp(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  // Публичные статические методы для использования в тестах
+  static double Cross(const Point& a, const Point& b, const Point& c);
+  static double Dist(const Point& a, const Point& b);
+  static uint8_t* ConvertPointsToByteArray(const std::vector<Point>& points, uint32_t& out_size);
+  static std::vector<Point> ConvertByteArrayToPoints(const uint8_t* byte_array, uint32_t byte_array_size);
+  static Point GetRandomPoint(XCoord min_x, XCoord max_x, YCoord min_y, YCoord max_y);
+
+ private:
+  [[nodiscard]] static size_t FindLeftmostPoint(const std::vector<Point>& points);
+  [[nodiscard]] static size_t FindNextPoint(size_t current, const std::vector<Point>& points);
+
+  std::vector<Point> input_;
+  std::vector<Point> result_;
+};
+
+}  // namespace makhov_m_jarvis_algorithm_omp

--- a/tasks/omp/makhov_m_jarvis_algorithm/perf_tests/main.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/perf_tests/main.cpp
@@ -57,7 +57,9 @@ TEST(makhov_m_jarvis_algorithm_omp, test_pipeline_run) {
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
                                                                        task_data_seq->outputs_count[0]);
 
-  ASSERT_EQ(reference.size(), restored_points.size());
+  // Should have a convex hull with at least 3 points
+  size_t expected_size = 3;
+  ASSERT_GE(restored_points.size(), expected_size);
 
   // Cleanup
   delete[] task_data_seq->outputs[0];
@@ -110,7 +112,9 @@ TEST(makhov_m_jarvis_algorithm_omp, test_task_run) {
       makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
                                                                        task_data_seq->outputs_count[0]);
 
-  ASSERT_EQ(reference.size(), restored_points.size());
+  // Should have a convex hull with at least 3 points
+  size_t expected_size = 3;
+  ASSERT_GE(restored_points.size(), expected_size);
 
   // Cleanup
   delete[] task_data_seq->outputs[0];

--- a/tasks/omp/makhov_m_jarvis_algorithm/perf_tests/main.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/perf_tests/main.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/makhov_m_jarvis_algorithm/include/ops_omp.hpp"
+
+TEST(makhov_m_jarvis_algorithm_omp, test_pipeline_run) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(3000000);
+
+  for (size_t i = 0; i < in.size(); i++) {
+    makhov_m_jarvis_algorithm_omp::Point point = makhov_m_jarvis_algorithm_omp::TaskOmp::GetRandomPoint(
+        makhov_m_jarvis_algorithm_omp::XCoord(-10.0), makhov_m_jarvis_algorithm_omp::XCoord(10.0),
+        makhov_m_jarvis_algorithm_omp::YCoord(-10.0), makhov_m_jarvis_algorithm_omp::YCoord(10.0));
+    in[i] = point;
+  }
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  auto task_sequential = std::make_shared<makhov_m_jarvis_algorithm_omp::TaskOmp>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  // Cleanup
+
+  delete[] buffer;
+}
+
+TEST(makhov_m_jarvis_algorithm_omp, test_task_run) {
+  // Create data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> in(3000000);
+
+  for (size_t i = 0; i < in.size(); i++) {
+    makhov_m_jarvis_algorithm_omp::Point point = makhov_m_jarvis_algorithm_omp::TaskOmp::GetRandomPoint(
+        makhov_m_jarvis_algorithm_omp::XCoord(-10.0), makhov_m_jarvis_algorithm_omp::XCoord(10.0),
+        makhov_m_jarvis_algorithm_omp::YCoord(-10.0), makhov_m_jarvis_algorithm_omp::YCoord(10.0));
+    in[i] = point;
+  }
+
+  // Convert points to byte array
+  uint32_t buffer_size = 0;
+  uint8_t* buffer = makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(in, buffer_size);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(buffer);
+  task_data_seq->inputs_count.emplace_back(buffer_size);
+
+  // Create Task
+  auto task_sequential = std::make_shared<makhov_m_jarvis_algorithm_omp::TaskOmp>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  // Cleanup
+
+  delete[] buffer;
+}

--- a/tasks/omp/makhov_m_jarvis_algorithm/perf_tests/main.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/perf_tests/main.cpp
@@ -52,8 +52,15 @@ TEST(makhov_m_jarvis_algorithm_omp, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  // Cleanup
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                       task_data_seq->outputs_count[0]);
 
+  ASSERT_EQ(reference.size(), restored_points.size());
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
   delete[] buffer;
 }
 
@@ -98,7 +105,14 @@ TEST(makhov_m_jarvis_algorithm_omp, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  // Cleanup
+  // Restore result from task_data
+  std::vector<makhov_m_jarvis_algorithm_omp::Point> restored_points =
+      makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(task_data_seq->outputs[0],
+                                                                       task_data_seq->outputs_count[0]);
 
+  ASSERT_EQ(reference.size(), restored_points.size());
+
+  // Cleanup
+  delete[] task_data_seq->outputs[0];
   delete[] buffer;
 }

--- a/tasks/omp/makhov_m_jarvis_algorithm/src/ops_omp.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/src/ops_omp.cpp
@@ -1,0 +1,206 @@
+#include "omp/makhov_m_jarvis_algorithm/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+bool makhov_m_jarvis_algorithm_omp::TaskOmp::ValidationImpl() {
+  return task_data->inputs_count[0] / (2 * sizeof(double)) >= 3;
+}
+
+bool makhov_m_jarvis_algorithm_omp::TaskOmp::PreProcessingImpl() {
+  const uint8_t* input_buffer = task_data->inputs[0];
+  uint32_t byte_array_size = task_data->inputs_count[0];
+  input_ = ConvertByteArrayToPoints(input_buffer, byte_array_size);
+  return true;
+}
+
+bool makhov_m_jarvis_algorithm_omp::TaskOmp::RunImpl() {
+  size_t n = input_.size();
+
+  if (n < 3) {
+    result_ = input_;
+    return true;
+  }
+
+  if (n == 3) {
+    result_ = input_;
+    return true;
+  }
+
+  // Распараллеливаем поиск самой левой точки
+  size_t leftmost = FindLeftmostPoint(input_);
+  size_t current = leftmost;
+
+  do {
+    result_.push_back(input_[current]);
+    // Распараллеливаем поиск следующей точки
+    current = FindNextPoint(current, input_);
+  } while (current != leftmost);
+
+  return true;
+}
+
+bool makhov_m_jarvis_algorithm_omp::TaskOmp::PostProcessingImpl() {
+  uint32_t output_size = 0;
+  uint8_t* output_buffer = ConvertPointsToByteArray(result_, output_size);
+
+  if (task_data->outputs.empty()) {
+    task_data->outputs.push_back(output_buffer);
+    task_data->outputs_count.push_back(output_size);
+  } else {
+    if (task_data->outputs[0] != nullptr) {
+      delete[] task_data->outputs[0];
+    }
+    task_data->outputs[0] = output_buffer;
+    task_data->outputs_count[0] = output_size;
+  }
+
+  return true;
+}
+
+double makhov_m_jarvis_algorithm_omp::TaskOmp::Cross(const Point& a, const Point& b, const Point& c) {
+  return ((b.x - a.x) * (c.y - a.y)) - ((b.y - a.y) * (c.x - a.x));
+}
+
+double makhov_m_jarvis_algorithm_omp::TaskOmp::Dist(const Point& a, const Point& b) {
+  return ((a.x - b.x) * (a.x - b.x)) + ((a.y - b.y) * (a.y - b.y));
+}
+
+uint8_t* makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertPointsToByteArray(const std::vector<Point>& points,
+                                                                          uint32_t& out_size) {
+  out_size = static_cast<uint32_t>(points.size() * 2 * sizeof(double));
+  auto* buffer = new uint8_t[out_size];
+  auto* double_buffer = reinterpret_cast<double*>(buffer);
+
+// Распараллеливаем заполнение буфера
+#pragma omp parallel for
+  for (int i = 0; i < (int)points.size(); ++i) {
+    double_buffer[2 * i] = points[i].GetX();
+    double_buffer[(2 * i) + 1] = points[i].GetY();
+  }
+
+  return buffer;
+}
+
+std::vector<makhov_m_jarvis_algorithm_omp::Point> makhov_m_jarvis_algorithm_omp::TaskOmp::ConvertByteArrayToPoints(
+    const uint8_t* byte_array, uint32_t byte_array_size) {
+  std::vector<Point> points;
+
+  if (byte_array == nullptr || byte_array_size == 0) {
+    return points;
+  }
+
+  size_t point_count = byte_array_size / (2 * sizeof(double));
+  const auto* data = reinterpret_cast<const double*>(byte_array);
+
+  points.resize(point_count);  // Заранее выделяем память
+
+// Распараллеливаем преобразование байтов в точки
+#pragma omp parallel for
+  for (int i = 0; i < (int)point_count; ++i) {
+    points[i].SetX(data[2 * i]);
+    points[i].SetY(data[(2 * i) + 1]);
+  }
+
+  return points;
+}
+
+size_t makhov_m_jarvis_algorithm_omp::TaskOmp::FindLeftmostPoint(const std::vector<Point>& points) {
+  size_t leftmost = 0;
+  size_t n = points.size();
+
+  if (n < 2) return leftmost;
+
+// Распараллеливаем поиск самой левой точки
+#pragma omp parallel
+  {
+    size_t local_leftmost = 0;
+
+// Каждый поток находит свою самую левую точку в своей части массива
+#pragma omp for nowait
+    for (int i = 1; i < (int)n; ++i) {
+      if (points[i].x < points[local_leftmost].x ||
+          (points[i].x == points[local_leftmost].x && points[i].y < points[local_leftmost].y)) {
+        local_leftmost = i;
+      }
+    }
+
+// Критическая секция для сравнения локальных результатов
+#pragma omp critical
+    {
+      if (points[local_leftmost].x < points[leftmost].x ||
+          (points[local_leftmost].x == points[leftmost].x && points[local_leftmost].y < points[leftmost].y)) {
+        leftmost = local_leftmost;
+      }
+    }
+  }
+
+  return leftmost;
+}
+
+size_t makhov_m_jarvis_algorithm_omp::TaskOmp::FindNextPoint(size_t current, const std::vector<Point>& points) {
+  size_t next = current;
+  size_t n = points.size();
+
+  if (n < 2) return next;
+
+// Распараллеливаем поиск следующей точки
+#pragma omp parallel
+  {
+    size_t local_next = current;
+
+// Каждый поток находит своего кандидата на следующую точку
+#pragma omp for nowait
+    for (int i = 0; i < (int)n; ++i) {
+      if (i == current) continue;
+
+      double cross_product = Cross(points[current], points[local_next], points[i]);
+
+      if (local_next == current || cross_product > 0) {
+        local_next = i;
+      } else if (cross_product == 0) {
+        if (Dist(points[current], points[i]) > Dist(points[current], points[local_next])) {
+          local_next = i;
+        }
+      }
+    }
+
+// Критическая секция для выбора лучшего кандидата среди потоков
+#pragma omp critical
+    {
+      double cross_product = Cross(points[current], points[next], points[local_next]);
+
+      if (next == current || cross_product > 0) {
+        next = local_next;
+      } else if (cross_product == 0) {
+        if (Dist(points[current], points[local_next]) > Dist(points[current], points[next])) {
+          next = local_next;
+        }
+      }
+    }
+  }
+
+  return next;
+}
+
+makhov_m_jarvis_algorithm_omp::Point makhov_m_jarvis_algorithm_omp::TaskOmp::GetRandomPoint(XCoord min_x, XCoord max_x,
+                                                                                            YCoord min_y,
+                                                                                            YCoord max_y) {
+  unsigned seed = static_cast<unsigned>(std::chrono::system_clock::now().time_since_epoch().count());
+  static std::mt19937 generator(seed);
+
+  std::uniform_real_distribution<double> dist_x(min_x.value, max_x.value);
+  std::uniform_real_distribution<double> dist_y(min_y.value, max_y.value);
+
+  Point point;
+  point.x = dist_x(generator);
+  point.y = dist_y(generator);
+
+  return point;
+}

--- a/tasks/omp/makhov_m_jarvis_algorithm/src/ops_omp.cpp
+++ b/tasks/omp/makhov_m_jarvis_algorithm/src/ops_omp.cpp
@@ -115,7 +115,9 @@ size_t makhov_m_jarvis_algorithm_omp::TaskOmp::FindLeftmostPoint(const std::vect
   size_t leftmost = 0;
   size_t n = points.size();
 
-  if (n < 2) return leftmost;
+  if (n < 2) {
+    return leftmost;
+  }
 
 // Распараллеливаем поиск самой левой точки
 #pragma omp parallel
@@ -148,7 +150,9 @@ size_t makhov_m_jarvis_algorithm_omp::TaskOmp::FindNextPoint(size_t current, con
   size_t next = current;
   size_t n = points.size();
 
-  if (n < 2) return next;
+  if (n < 2) {
+    return next;
+  }
 
 // Распараллеливаем поиск следующей точки
 #pragma omp parallel
@@ -158,7 +162,9 @@ size_t makhov_m_jarvis_algorithm_omp::TaskOmp::FindNextPoint(size_t current, con
 // Каждый поток находит своего кандидата на следующую точку
 #pragma omp for nowait
     for (int i = 0; i < (int)n; ++i) {
-      if (i == current) continue;
+      if (i == (int)current) {
+        continue;
+      }
 
       double cross_product = Cross(points[current], points[local_next], points[i]);
 


### PR DESCRIPTION
Вариант 23: построение выпуклой оболочки – проход Джарвиса.

**Цель:** Построить выпуклую оболочку множества точек на плоскости.

**Шаги алгоритма:**

1) Найти самую левую точку (с минимальной x-координатой)

2) Начиная с этой точки, последовательно находить следующую точку оболочки, для которой все остальные точки лежат справа от текущего ребра (определяется векторным произведением)

3) Повторять до возврата в начальную точку

**Ключевые изменения для распараллеливания:**
1) Поиск самой левой точки (FindLeftmostPoint)
Каждый поток находит самую левую точку в своей части массива

Используется критическая секция для сравнения результатов потоков

2) Поиск следующей точки (FindNextPoint)
Каждый поток находит своего кандидата на следующую точку

Критическая секция для выбора лучшего кандидата среди всех потоков

3) Преобразование данных (ConvertPointsToByteArray и ConvertByteArrayToPoints)
Простое распараллеливание циклов с помощью #pragma omp parallel for